### PR TITLE
Various Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .byebug_history
 tmp
 Gemfile.lock
+package-lock.json

--- a/condenser.gemspec
+++ b/condenser.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.2.0'
 
   s.add_runtime_dependency  "erubi", '~> 1.0'
-  s.add_runtime_dependency  "rack",  '> 1', '< 3'
+  s.add_runtime_dependency  "rack",  '> 1'
   s.add_runtime_dependency  "listen"
 
   s.add_development_dependency "ruby-ejs", '~> 1.0'  

--- a/lib/condenser/asset.rb
+++ b/lib/condenser/asset.rb
@@ -67,7 +67,9 @@ class Condenser
     def process_dependencies
       deps = @environment.cache.fetch "direct-deps/#{cache_key}" do
         process
-        @process_dependencies.map { |fn| [normalize_filename_base(fn[0]), fn[1]] }
+        # Sort so etag and cache key are same irrelevant of ordering of
+        # dependencies
+        @process_dependencies.map { |fn| [normalize_filename_base(fn[0]), fn[1]] }.sort_by { |d| d[0] }
       end
     
       deps.inject([]) do |memo, i|
@@ -82,7 +84,9 @@ class Condenser
     def export_dependencies
       deps = @environment.cache.fetch "export-deps/#{cache_key}" do
         process
-        (@export_dependencies + @process_dependencies).map { |fn| [normalize_filename_base(fn[0]), fn[1]] }
+        # Sort so etag and cache key are same irrelevant of ordering of
+        # dependencies
+        (@export_dependencies + @process_dependencies).map { |fn| [normalize_filename_base(fn[0]), fn[1]] }.sort_by { |d| d[0] }
       end
       
       deps.inject([]) do |memo, i|
@@ -331,6 +335,14 @@ class Condenser
           @processors = data[:processors]
           @processors_loaded = true
           @processed = true
+          
+          digestor = @environment.digestor.new
+          digestor << data[:source]
+          all_dependenies(export_dependencies, Set.new, :export_dependencies) do |dep|
+            digestor << dep.source
+          end
+          data[:etag] = digestor.digest.unpack('H*'.freeze).first
+          @etag = data[:etag]
           data
         end
       end
@@ -347,6 +359,7 @@ class Condenser
       @default_export = result[:default_export]
       @exports = result[:exports]
       @processors = result[:processors]
+      @etag = result[:etag]
       load_processors
 
       @processed = true
@@ -371,6 +384,8 @@ class Condenser
           process
           dirname, basename, extensions, mime_types = @environment.decompose_path(@filename)
           data = {
+            etag: @etag,
+            
             source: @source.dup,
             source_file: @source_file,
         
@@ -408,7 +423,7 @@ class Condenser
           end
         end
 
-        Export.new(@environment, data, etag: etag)
+        Export.new(@environment, data)
       end
     end
     
@@ -449,17 +464,8 @@ class Condenser
     end
     
     def etag
-      return @etag if @etag
-
-      digestor = @environment.digestor.new
-      all_export_dependencies.each do |sf|
-        digestor << File.read(sf)
-      end
-      linked_assets.each do |la|
-        digestor << la.etag
-      end
-      
-      digestor.digest.unpack('H*'.freeze).first
+      process
+      @etag
     end
     
     def integrity

--- a/lib/condenser/asset.rb
+++ b/lib/condenser/asset.rb
@@ -12,7 +12,7 @@ class Condenser
     include EncodingUtils
     
     attr_reader :environment, :filename, :content_types, :source_file, :source_path
-    attr_reader :linked_assets, :content_types_digest, :exports
+    attr_reader :content_types_digest, :exports
     attr_writer :source, :sourcemap
 
     attr_accessor :imports, :processed
@@ -87,6 +87,21 @@ class Condenser
       
       deps.inject([]) do |memo, i|
         i[0] = File.join(@environment.base, i[0].delete_prefix('!')) if i[0].start_with?('!') && @environment.base
+        @environment.resolve(i[0], File.dirname(@source_file), accept: i[1], npm: true).each do |asset|
+          memo << asset
+        end
+        memo
+      end
+    end
+    
+    def linked_assets
+      deps = @environment.cache.fetch "linked-assets/#{cache_key}" do
+        process
+        @linked_assets.map { |fn| [normalize_filename_base(fn[0]), fn[1]] }
+      end
+      
+      deps.inject([]) do |memo, i|
+        i[0] = File.join(@environment.base, i[0].delete_prefix('!')) if i[0].start_with?('!') && @environment.base
         @environment.resolve(i[0], File.dirname(@source_file), accept: i[1]).each do |asset|
           memo << asset
         end
@@ -124,7 +139,7 @@ class Condenser
     end
     
     def all_process_dependencies(visited = Set.new)
-      f = []
+      f = Set.new
       if !visited.include?(@source_file)
         f << @source_file
         visited << self.source_file
@@ -137,7 +152,7 @@ class Condenser
     end
     
     def all_export_dependencies(visited = Set.new)
-      f = []
+      f = Set.new
       if !visited.include?(@source_file)
         f << @source_file
         visited << self.source_file
@@ -194,7 +209,7 @@ class Condenser
         ]
       end
 
-      @ecv = Digest::SHA1.base64digest(JSON.generate(f))
+      @ecv = Digest::SHA1.hexdigest(JSON.generate(f))
     end
     
     def needs_reprocessing!
@@ -298,6 +313,7 @@ class Condenser
           data[:digest_name] = @environment.digestor.name.sub(/^.*::/, '').downcase
           data[:process_dependencies] = normialize_dependency_names(data[:process_dependencies])
           data[:export_dependencies] = normialize_dependency_names(data[:export_dependencies])
+          data[:linked_assets] = normialize_dependency_names(data[:linked_assets])
 
           # Do this here and at the end so cache_key can be calculated if we
           # run this block
@@ -392,7 +408,7 @@ class Condenser
           end
         end
 
-        Export.new(@environment, data)
+        Export.new(@environment, data, etag: etag)
       end
     end
     
@@ -431,7 +447,20 @@ class Condenser
       process
       @digest.unpack('H*'.freeze).first
     end
-    alias_method :etag, :hexdigest
+    
+    def etag
+      return @etag if @etag
+
+      digestor = @environment.digestor.new
+      all_export_dependencies.each do |sf|
+        digestor << File.read(sf)
+      end
+      linked_assets.each do |la|
+        digestor << la.etag
+      end
+      
+      digestor.digest.unpack('H*'.freeze).first
+    end
     
     def integrity
       process
@@ -439,7 +468,7 @@ class Condenser
     end
     
     def to_json
-      { path: path, digest: hexdigest, size: size, integrity: integrity }
+      { path: path, etag: etag, digest: hexdigest, size: size, integrity: integrity }
     end
     
     def write(output_directory)

--- a/lib/condenser/export.rb
+++ b/lib/condenser/export.rb
@@ -5,7 +5,7 @@ class Condenser
 
     attr_reader :filename, :source, :sourcemap, :content_types, :digest, :digest_name, :etag
 
-    def initialize(env, input={}, etag: nil)
+    def initialize(env, input={})
       @environment = env
       
       @source = input[:source]
@@ -14,7 +14,7 @@ class Condenser
       @content_types = input[:content_types]
       @digest = input[:digest]
       @digest_name = input[:digest_name]
-      @etag = etag
+      @etag = input[:etag]
     end
     
     def path

--- a/lib/condenser/export.rb
+++ b/lib/condenser/export.rb
@@ -3,9 +3,9 @@
 class Condenser
   class Export
 
-    attr_reader :filename, :source, :sourcemap, :content_types, :digest, :digest_name
+    attr_reader :filename, :source, :sourcemap, :content_types, :digest, :digest_name, :etag
 
-    def initialize(env, input={})
+    def initialize(env, input={}, etag: nil)
       @environment = env
       
       @source = input[:source]
@@ -14,6 +14,7 @@ class Condenser
       @content_types = input[:content_types]
       @digest = input[:digest]
       @digest_name = input[:digest_name]
+      @etag = etag
     end
     
     def path
@@ -45,7 +46,6 @@ class Condenser
     def hexdigest
       @digest.unpack('H*'.freeze).first
     end
-    alias_method :etag, :hexdigest
     
     def integrity
       "#{@digest_name}-#{[@digest].pack('m0')}"
@@ -55,6 +55,7 @@ class Condenser
       {
         'path' => path,
         'size' => size,
+        'etag' => etag,
         'digest' => hexdigest,
         'integrity' => integrity
       }

--- a/lib/condenser/helpers/parse_helpers.rb
+++ b/lib/condenser/helpers/parse_helpers.rb
@@ -5,7 +5,7 @@ module Condenser::ParseHelpers
   attr_accessor :matched
 
   def eos?
-    @index >= (@source.size - 1)
+    @index >= @source.size
   end
 
   def scan_until(r)
@@ -58,9 +58,22 @@ module Condenser::ParseHelpers
   end
 
   def gobble(r)
-    m = @source.match(r, @index)
-    if m&.begin(0) == @index
-      scan_until(r)
+    if r.is_a?(Regexp)
+      m = @source.match(r, @index)
+      if m&.begin(0) == @index
+        scan_until(r)
+      end
+    else
+      forward(1)
+      @source[@index-1];
+    end
+  end
+
+  def peek(n=1)
+    if n.is_a?(Regexp)
+      @source.match(n, @index)
+    else
+      @source.slice(@index, n)
     end
   end
 

--- a/lib/condenser/manifest.rb
+++ b/lib/condenser/manifest.rb
@@ -74,7 +74,7 @@ class Condenser
       @data[asset.filename] = export.to_json
       outputs = export.write(@dir)
       asset.linked_assets.each do |la|
-        @environment.resolve(la).each { |a| outputs += add_asset(a) }
+        outputs += add_asset(la)
       end
       outputs
     end

--- a/lib/condenser/processors/babel_processor.rb
+++ b/lib/condenser/processors/babel_processor.rb
@@ -83,11 +83,17 @@ class Condenser::BabelProcessor < Condenser::NodeProcessor
       end
     end
     
-    
+    opts['preset']&.each do |preset|
+      preset[0] = preset[0].gsub(/"@?babel[\/-][^"]+"/) { |m| "require(#{m})"}
+    end
+    opts['plugins']&.each do |preset|
+      preset[0] = preset[0].gsub(/"@?babel[\/-][^"]+"/) { |m| "require(#{m})"}
+    end
+
     result = exec_runtime(<<-JS)
       const babel = require("#{File.join(npm_module_path('@babel/core'))}");
       const source = #{JSON.generate(input[:source])};
-      const options = #{JSON.generate(opts).gsub(/"@?babel[\/-][^"]+"/) { |m| "require(#{m})"}};
+      const options = #{JSON.generate(opts)};
       
       let imports = [];
       let defaultExport = false;

--- a/lib/condenser/processors/css_media_combiner_processor.rb
+++ b/lib/condenser/processors/css_media_combiner_processor.rb
@@ -66,11 +66,11 @@ class Condenser::CSSMediaCombinerProcessor
           @stack.pop
         end
       else
-        case scan_until(/(@media[^\{]*{|\Z)/)
+        case scan_until(/(@media[^\{]*{|\z)/)
         when ''
           output << pre_match
         else
-          output << pre_match
+          output << pre_match.rstrip
           @selectors << matched.squish
           @stack << :media_query
         end

--- a/lib/condenser/processors/js_analyzer.rb
+++ b/lib/condenser/processors/js_analyzer.rb
@@ -16,7 +16,9 @@ class Condenser::JSAnalyzer
     @sourcefile = input[:source_file]
     @source = input[:source]
     @stack =  [:main]
+    @previous = [[]]
 
+    input[:linked_assets] ||= Set.new
     input[:export_dependencies] ||= Set.new
 
     scan_until(/\A(\/\/[^\n]*(\n|\z))*/)
@@ -38,14 +40,19 @@ class Condenser::JSAnalyzer
         scan_until(/(\$\{|\`)/)
         case matched
         when '`'
-          @stack.pop
+          @stack.pop if pre_match[-1] != "\\" && pre_match[-1] != "\\"
         when '${'
           @stack << :tick_statment
         end
 
       when :import
-        scan_until(/[\"\'\`]/)
-        input[:export_dependencies] << case matched
+        scan_until(/[\"\'\`\(]/)
+        dynamic = if matched == "("
+          scan_until(/[\"\'\`]/)
+          true
+        end
+        
+        filename = case matched
         when "\""
           double_quoted_value
         when "'"
@@ -53,7 +60,14 @@ class Condenser::JSAnalyzer
         when '`'
           tick_quoted_value
         end
-        scan_until(/(;|\n)/)
+
+        if dynamic
+          input[:process_dependencies] << filename
+          input[:linked_assets] << filename 
+        else
+          input[:export_dependencies] << filename
+        end
+        scan_until(/(;|\n|\))/)
         @stack.pop
 
       when :export
@@ -63,6 +77,7 @@ class Condenser::JSAnalyzer
 
         if gobble(/\{/)
           @stack << :brackets
+          @previous << []
         elsif gobble(/\*/)
           @stack << :export_from
         else
@@ -88,37 +103,57 @@ class Condenser::JSAnalyzer
         case matched
         when '//'
           scan_until(/(\n|\z)/)
+          @previous.last << :single_line_comment
         when '/*'
           scan_until(/\*\//)
+          @previous.last << :multi_line_comment
         when '"'
           double_quoted_value
+          @previous.last << :double_quoted_value
         when "'"
           single_quoted_value
+          @previous.last << :single_quoted_value
         when '`'
           @stack << :tick_value
         when '/'
-          if match_index = @source.rindex(/(\w+|\)|\])\s*\//, @index)
+          if pre_match.match(/(\W|\A)(void|typeof|return|export)\z/)
+            regex_value
+          elsif match_index = @source.rindex(/(\w+|\)|\])\s*\//, @index)
             match = @source.match(/(\w+|\)|\])\s*\//, match_index)
-            if match[0].length + match_index != @index
+            if match[1] =~ /\)\z/ && @previous.last.last == :loop
+              regex_value
+            elsif %w(void typeof return export).include?(match[1])
+              regex_value
+            elsif match[0].length + match_index != @index
               regex_value
             end
           else
             regex_value
           end
         when '('
-          @stack.push :parenthesis
+          @stack << if pre_match =~ /\W*(for|while)\s*\z/
+            :loop
+          else
+            :parenthesis
+          end
         when ')'
-          raise unexptected_token(")") if @stack.last != :parenthesis
-          @stack.pop
+          raise unexptected_token(")") if @stack.last != :parenthesis && @stack.last != :loop
+          @previous.last << @stack.pop
         when '{'
           @stack.push :brackets
+          @previous << []
         when '}'
           case @stack.last
           when :tick_statment
             @stack.pop
           when :brackets
             @stack.pop
-            @stack << :export_from if @stack.last == :export
+            @previous.pop
+            @previous.last << :brackets
+            if @stack.last == :export
+              @stack.pop
+              @stack << :export_from if peek(/\s+from/i)
+            end
           else
             raise unexptected_token("}")
           end
@@ -127,9 +162,7 @@ class Condenser::JSAnalyzer
             @stack << :export
           end
         when 'import'
-          if @stack.last == :main
-            @stack << :import
-          end
+          @stack << :import
         else
           @stack.pop
         end
@@ -144,6 +177,8 @@ class Condenser::JSAnalyzer
         last_stack = @stack.last
       end
     end
+    
+    raise Condenser::SyntaxError, "Unexpected EOF" if !@stack.empty? && @stack.last != :main
   end
   
   def unexptected_token(token)
@@ -153,7 +188,7 @@ class Condenser::JSAnalyzer
 
     message = "Unexpected token #{token} #{@sourcefile} #{lineno.to_s.rjust(4)}:#{(@index-start)}"
     message << "\n#{lineno.to_s.rjust(4)}: " << @source[start..uptop]
-    message << "\n      #{'-'* (@index-1-start)}#{'^'*(@matched.length)}"
+    message << "\n      #{'-'* ([@index-1-start,1].max)}#{'^'*([@matched.length,1].max)}"
     message << "\n"
     
     syntax_error = Condenser::SyntaxError.new(message)
@@ -164,18 +199,15 @@ class Condenser::JSAnalyzer
   def double_quoted_value
     ret_value = String.new
 
-    while scan_until(/[\"\n]/)
-      if matched == "\n"
+    while scan_until(/[\"\n\\]/)
+      case matched
+      when "\n"
         raise unexptected_token("\\n")
-      elsif matched == "\""
-        if pre_match[-1] != "\\"
-          ret_value << pre_match
-          return ret_value
-        else
-          ret_value << pre_match << "\\\""
-        end
-
-        
+      when "\\"
+        ret_value << pre_match << matched << gobble(1)
+      when "\""
+        ret_value << pre_match
+        return ret_value
       else
         ret_value << match
       end
@@ -213,14 +245,35 @@ class Condenser::JSAnalyzer
   def regex_value
     ret_value = String.new
 
-    while scan_until(/\//)
-      if matched == "/" && pre_match[-1] != "\\"
-        ret_value << pre_match
-        return ret_value
-      else
-        ret_value << pre_match
+    regex_stack =  ['/']
+    while !regex_stack.empty?
+      
+      scan_until(/[\/\[\]]/)
+      escaped = pre_match[-1] == "\\" && pre_match[-2] != "\\"
+      ret_value << pre_match
+      case matched
+      when "["
+        regex_stack << '[' if !escaped && regex_stack.last != "["
+        ret_value << matched
+      when "]"
+        regex_stack.pop if !escaped && regex_stack.last == "["
+        ret_value << matched
+      when "/"
+        # From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class
+        # 
+        # The lexical grammar does a very rough parse of regex literals, so
+        # that it does not end the regex literal at a / character which appears
+        # within a character class. This means /[/]/ is valid without needing
+        # to escape the /.
+        if !escaped && regex_stack.last != "[" && regex_stack.pop != "/"
+          raise unexptected_token("/")
+        else
+          ret_value << matched
+        end
       end
     end
+
+    ret_value
   end
 
 end

--- a/lib/condenser/processors/js_analyzer.rb
+++ b/lib/condenser/processors/js_analyzer.rb
@@ -98,7 +98,7 @@ class Condenser::JSAnalyzer
         @stack.pop
         
       else
-        scan_until(/(\/\/|\/\*|\/|\(|\)|\{|\}|\"|\'|\`|export|import|\z)/)
+        scan_until(/(\/\/|\/\*|\/|\(|\)|\{|\}|\"|\'|\`|export(?![[:alnum:]])|import(?![[:alnum:]])|\z)/)
 
         case matched
         when '//'

--- a/lib/condenser/processors/rollup_processor.rb
+++ b/lib/condenser/processors/rollup_processor.rb
@@ -3,38 +3,93 @@
 require 'json'
 require 'tmpdir'
 
-class Condenser::RollupProcessor < Condenser::NodeProcessor
+class Condenser::RollupProcessor
   
-  attr_accessor :options
+  @@setup = false
   
-  def initialize(dir = nil, options = {})
-    super(dir)
-    npm_install('rollup', '@rollup/plugin-commonjs', '@rollup/plugin-node-resolve')
+  def self.setup(environment)
+    install_npm_packages(environment.npm_path)
+  end
+  
+  def self.install_npm_packages(npm_path)
+    return if @@setup
     
-    @options = options.freeze
+    ::Condenser::NodeProcessor.new(npm_path).npm_install(
+      'rollup',
+      '@rollup/plugin-commonjs',
+      '@rollup/plugin-node-resolve',
+      '@rollup/plugin-replace'
+    )
+    @@setup = true
+  end
+  
+  def self.call(environment, input)
+    new(environment.npm_path).call(environment, input)
+  end
+
+  def name
+    self.class.name
+  end
+  
+  def options
+    {prefix: @prefix, inline: @inline}
+  end
+  
+  # @param prefix [string] string to prefix to the url of dynamic imports
+  # @param inline [symbol] :inline will inline all the imports in the 
+  #                        output file if possible.
+  #                        false will keep all the dynamic import.
+  #                        :local will not inline URLS.
+  def initialize(dir = nil, prefix: nil, inline: :imports)
+    self.class.install_npm_packages(dir)
+    @npm_dir = dir
+    @prefix = prefix
+    @inline = inline
   end
 
   def call(environment, input)
-    @environment = environment
-    @input = input
+    Runner.new(@npm_dir, prefix: @prefix, inline: @inline).call(environment, input)
+  end
+  
+  
+  class Runner < Condenser::NodeProcessor
+    def initialize(dir = nil, prefix: nil, inline: :imports)
+      super(dir)
+      @prefix = prefix
+      @inline = inline
+    end
+
+    def call(environment, input)
+      @environment = environment
+      @input = input
     
-    Dir.mktmpdir do |output_dir|
-      @entry = File.join(output_dir, 'entry.js')
+      @input_dir = File.realdirpath(Dir.mktmpdir)
+      @output_dir = File.realdirpath(Dir.mktmpdir)
+    
+      @entry = File.join(@input_dir, 'entry.js')
+    
       input_options = {
         input: @entry
       }
+    
       output_options = {
-        file: File.join(output_dir, 'result.js'),
-        format: 'iife',
-        # output: { sourcemap: true, format: 'iife' },
+        dir: @output_dir,
+        format: 'es',
         globals: [],
-        sourcemap: true
+        sourcemap: false,
+        inlineDynamicImports: true,
+        generatedCode: {
+          arrowFunctions: true,
+          constBindings: true,
+          objectShorthand: true,
+          preset: 'es2015',
+        }
       }
+
       if input[:source] =~ /export\s+{[^}]+};?\z/i
         output_options[:name] = File.basename(input[:filename], ".*").capitalize
-        # output_options[:output][:name] = File.basename(input[:filename], ".*").capitalize
       end
-      
+
       exec_runtime(<<-JS, @entry)
         const fs    = require('fs');
         const path  = require('path');
@@ -75,14 +130,19 @@ class Condenser::RollupProcessor < Condenser::NodeProcessor
           buffer += chunk;
           buffer = emitMessages(buffer);
         });
-        
+      
         const rollup = require("#{npm_module_path('rollup')}");
         const commonjs = require("#{npm_module_path('@rollup/plugin-commonjs')}");
         const nodeResolve = require("#{npm_module_path('@rollup/plugin-node-resolve')}").nodeResolve;
+        const asyncWalk = require("#{npm_module_path('estree-walker')}").asyncWalk;
+        const MagicString = require("#{npm_module_path('magic-string')}");
+        const replace = require("#{npm_module_path('@rollup/plugin-replace')}");
+      
         var rid = 0;
         var renderStack = {};
+        var dynamicImports = {};
         var nodeResolver = null;
-        
+      
         function request(method, args) {
           var trid = rid;
           rid += 1;
@@ -109,8 +169,58 @@ class Condenser::RollupProcessor < Condenser::NodeProcessor
 
         const inputOptions = #{JSON.generate(input_options)};
         inputOptions.plugins = [];
-        inputOptions.plugins.push({
+        
+        inputOptions.plugins.push(replace({
+            preventAssignment: true,
+            values: {
+              "process.env.NODE_ENV": JSON.stringify("production")
+            }
+        }), {
+          name: 'transform',
+          transform: async function(code, id) {
+            const magicString = new MagicString(code);
+            const ast = this.parse(code, { sourceType: 'module' });
+
+            await asyncWalk(ast, {
+              async enter(node) {
+                if(['ImportExpression'].includes(node.type) && node.source.type == 'Literal') {
+                  const asset = await request('resolveDynamicImport', [node.source.value, id]);
+
+                  if (asset.export) {
+                    dynamicImports[asset.source] = asset;
+                    magicString.update(node.source.start, node.source.end, `'${asset.source}'`);
+                  } else {
+                    dynamicImports[node.source.value] = asset;
+                  }
+                } else if (node.type == 'ImportDeclaration' ) {
+                  if (node.value == '@arcgis/lumina/controllers') {
+                    magicString.update(node.start, node.end, `'@arcgis/components-controllers'`);
+                  }
+                }
+              }
+            });
+
+            return {
+              code: magicString.toString(),
+              map: null
+            };
+          }
+        }, {
           name: 'condenser',
+          resolveDynamicImport: function (importee, importer, options) {
+            const asset = dynamicImports[importee];
+            request('resolve!!!!', [importee, dynamicImports]);
+
+            if (!asset) {
+              return;
+            }
+          
+            if (asset.export) {
+              return false;
+            }
+          
+            return asset.source;
+          },
           resolveId: function (importee, importer, options) {
             if (importee.startsWith('\\0') || (importer && importer.startsWith('\\0'))) {
               return null;
@@ -127,36 +237,32 @@ class Condenser::RollupProcessor < Condenser::NodeProcessor
                 return value;
             });
           },
+        
           load: function(id) {
             if (id.startsWith('\\0')) {
               return null;
             }
 
-            return request('load', [id]).then(function(value) {
-              return value;
-            });
+            return request('load', [id]);
           }
         });
-        
+      
         inputOptions.plugins.push(nodeResolver);
         inputOptions.plugins.push(commonjs());
-        
-        // inputOptions.plugins.push({
-        //   name: 'nullHanlder',
-        //   resolveId: function (importee, importer, options) {
-        //     request('log', [importee, importer, options])
-        //     // request('error', ["AssetNotFound", importee, importer, renderStack]).then(function(value) {
-        //     //   process.exit(1);
-        //     // });
-        //   }
-        // });
-
+      
         const outputOptions = #{JSON.generate(output_options)};
+        outputOptions.paths = (id) => {
+            const asset = dynamicImports[id];
+          
+            if (asset) {
+              return asset.path;
+            }
+        }
 
         async function build() {
           try {
             // inputOptions.cache = await JSON.parse(request('get_cache', []));
-            
+          
             const bundle = await rollup.rollup(inputOptions);
             await bundle.write(outputOptions);
             // await request('set_cache', [JSON.stringify(bundle)]);
@@ -169,134 +275,177 @@ class Condenser::RollupProcessor < Condenser::NodeProcessor
 
         build();
       JS
-      
-      input[:source] = File.read(File.join(output_dir, 'result.js'))
+
+      input[:source] = File.read(File.join(@output_dir, 'entry.js'))
       input[:source].delete_suffix!("//# sourceMappingURL=result.js.map\n")
       # asset.map = File.read(File.join(output_dir, 'result.js.map'))
+      input
+    ensure
+      begin
+        [@input_dir, @output_dir].each { |dir| FileUtils.remove_entry(dir) }
+      rescue Errno::ENOENT
+      end
     end
-  end
   
-  def exec_runtime(script, input)
-    io = IO.popen([binary, '-e', script], 'r+')
-    buffer = String.new
+    def exec_runtime(script, input)
+      io = IO.popen([binary, '--max_old_space_size=5120', '-e', script], 'r+')
+      buffer = String.new
     
-    begin
+      begin
       
-      while IO.select([io]) && io_read = io.read_nonblock(1_024)
-        buffer << io_read
-        messages = buffer.split("\n\n")
+        while IO.select([io]) && io_read = io.read_nonblock(1_024)
+          buffer << io_read
+          messages = buffer.split("\n\n")
         
-        buffer = if buffer.end_with?("\n\n")
-          String.new
-        else
-          messages.pop
-        end
+          buffer = if buffer.end_with?("\n\n")
+            String.new
+          else
+            messages.pop
+          end
         
-        messages.each do |message|
-          message = JSON.parse(message)
-          
-          ret = case message['method']
-          when 'resolve'
-            importee, importer = message['args']
+          messages.each do |message|
+            message = JSON.parse(message)
+            # puts message.inspect
+            ret = case message['method']
+            when 'log'
+              puts message.inspect
+            when 'resolveDynamicImport'
+              importee, importer = message['args']
 
-            if importer.nil? && importee == @entry
-              @entry
-            elsif importee.start_with?('@babel/runtime') || importee.start_with?('core-js-pure') || importee.start_with?('regenerator-runtime')
-              x = File.join(npm_module_path, importee.gsub(/^\.\//, File.dirname(importer) + '/')).sub('/node_modules/regenerator-runtime', '/node_modules/regenerator-runtime/runtime.js')
-              x = "#{x}.js" if !x.end_with?('.js', '.mjs')
-              File.file?(x) ? x : (x.delete_suffix('.js') + "/index.js")
-            elsif npm_module_path && importee&.start_with?(npm_module_path)
-              x = importee.end_with?('.js', '.mjs') ? importee : "#{importee}.js"
-              x = (x.delete_suffix('.js') + "/index.js") if !File.file?(x)
-              x
-            elsif importee.start_with?('.') && importer.start_with?(npm_module_path)
-              x = File.expand_path(importee, File.dirname(importer))
-              x = "#{x}.js" if !x.end_with?('.js', '.mjs')
-              File.file?(x) ? x : (x.delete_suffix('.js') + "/index.js")
-            elsif importee.end_with?('*')
-              File.join(File.dirname(importee), '*')
-            else
-              @environment.find(importee, importer ? (@entry == importer ? @input[:source_file] : importer) : nil, accept: @input[:content_types].last)&.source_file
-            end
-          when 'load'
-            importee = message['args'].first
-            if importee == @entry
-              { code: @input[:source], map: @input[:map] }
-            elsif importee.end_with?('*')
-              importees = @environment.resolve(importee, importer ? File.dirname(@entry == importer ? @input[:source_file] : importer) : nil, accept: @input[:content_types].last)
-              code = String.new
-              code_imports = [];
-              importees.each_with_index.map do |f, i|
-                if f.has_default_export?
-                  code << "import _#{i} from '#{f.source_file}';\n"
-                  code_imports << "_#{i}"
-                elsif f.has_exports?
-                  code << "import * as _#{i} from '#{f.source_file}';\n"
-                  code_imports << "_#{i}"
+              asset = @environment.find(importee, importer ? (@entry == importer ? @input[:source_file] : importer) : nil, accept: @input[:content_types].last, npm: true)
+              asset ||= @environment.find(importee.delete_suffix('.js') + "/index.js", importer ? (@entry == importer ? @input[:source_file] : importer) : nil, accept: @input[:content_types].last, npm: true)
+              asset ||= @environment.find(importee.gsub(/\/[^\/]+$/, '')+ "/dist/index.js", importer ? (@entry == importer ? @input[:source_file] : importer) : nil, accept: @input[:content_types].last, npm: true)
+            
+              if asset.source_file == @input[:source_file]
+                {
+                  a: 2,
+                  path: File.join("/", *[@prefix, asset.path].compact),
+                  # source: File.join(@input_dir, asset.filename),
+                  source: @entry,
+                  export: false,
+                  # filename: asset.filename
+                }
+              else
+                if !@inline
+                  {
+                    a: 1,
+                    path: File.join("/", *[@prefix, asset.path].compact),
+                    source: File.join(@input_dir, asset.filename),
+                    export: true,
+                    filename: asset.filename
+                  }
                 else
-                  code << "import '#{f.source_file}';\n"
+                  {
+                    a: 3,
+                    export: false,
+                    source: asset.source_file,
+                    filename: asset.filename
+                  }
                 end
               end
-              
-              code += "export default [#{code_imports.join(', ')}];"
-
-              { code: code, map: nil }
-            else
-              asset = @environment.find(importee, accept: @input[:content_types].last)
-              if asset
-                { code: asset.source, map: asset.sourcemap }
-              else
-                nil
-              end
-            end
-          when 'error'
-            io.write(JSON.generate({rid: message['rid'], return: nil}))
             
-            case message['args'][0]
-            when 'AssetNotFound'
-              error_message = "Could not find import \"#{message['args'][1]}\" for \"#{message['args'][2]}\".\n\n"
-              error_message << build_tree(message['args'][3], input, message['args'][2])
-              raise exec_runtime_error(error_message)
-            else
-              raise exec_runtime_error(message['args'][0] + ': ' + message['args'][1])
-            end
-          # when 'set_cache'
-          #   @environment.cache.set('rollup', message['args'][0])
-          #   io.write(JSON.generate({rid: message['rid'], return: true}))
-          # when 'get_cache'
-          #   io.write(JSON.generate({rid: message['rid'], return: [(@environment.cache.get('rollup') || '{}')] }))
-          end
-          io.write(JSON.generate({rid: message['rid'], return: ret}))
-        end
-      end
-    rescue Errno::EPIPE, EOFError
-    end
-    
-    io.close
-    if $?.success?
-      true
-    else
-      raise exec_runtime_error(buffer)
-    end
-  end
+            when 'resolve'
+              importee, importer = message['args']
 
-  def build_tree(renderStack, from, to, visited: nil)
-    visited ||= []
-    return if visited.include?(from)
-    visited << from
-    
-    if renderStack[from].nil? || renderStack[from].empty?
-      nil
-    elsif renderStack[from].include?(to)
-      from
-    else
-      renderStack[from].each do |dep|
-        if tree = build_tree(renderStack, dep, to, visited: visited)
-          return "#{from}\n└ #{tree.lines.each_with_index.map{|l, i| "#{i == 0 ? '' : '    '}#{l}"}.join("")}"
+              if importer.nil? && importee == @entry
+                @entry
+              elsif importee.start_with?('@babel/runtime') || importee.start_with?('core-js-pure') || importee.start_with?('regenerator-runtime')
+                x = File.join(npm_module_path, importee.gsub(/^\.\//, File.dirname(importer) + '/')).sub('/node_modules/regenerator-runtime', '/node_modules/regenerator-runtime/runtime.js')
+                x = "#{x}.js" if !x.end_with?('.js', '.mjs')
+                File.file?(x) ? x : (x.delete_suffix('.js') + "/index.js")
+              elsif npm_module_path && importee&.start_with?(npm_module_path)
+                x = importee.end_with?('.js', '.mjs') ? importee : "#{importee}.js"
+                x = (x.delete_suffix('.js') + "/index.js") if !File.file?(x)
+                x
+              elsif importee.start_with?('.') && importer.start_with?(npm_module_path)
+                x = File.expand_path(importee, File.dirname(importer))
+                x = "#{x}.js" if !x.end_with?('.js', '.mjs')
+                File.file?(x) ? x : (x.delete_suffix('.js') + "/index.js")
+              elsif importee.end_with?('*')
+                File.join(File.dirname(importee), '*')
+              else
+                asset = @environment.find(importee, importer ? (@entry == importer ? @input[:source_file] : importer) : nil, accept: @input[:content_types].last, npm: true)&.source_file
+              end
+            when 'load'
+              importee = message['args'].first
+              if importee == @entry
+                { code: @input[:source], map: @input[:map] }
+              elsif importee.end_with?('*')
+                importees = @environment.resolve(importee, importer ? File.dirname(@entry == importer ? @input[:source_file] : importer) : nil, accept: @input[:content_types].last, npm: true)
+                code = String.new
+                code_imports = [];
+                importees.each_with_index.map do |f, i|
+                  if f.has_default_export?
+                    code << "import _#{i} from '#{f.source_file}';\n"
+                    code_imports << "_#{i}"
+                  elsif f.has_exports?
+                    code << "import * as _#{i} from '#{f.source_file}';\n"
+                    code_imports << "_#{i}"
+                  else
+                    code << "import '#{f.source_file}';\n"
+                  end
+                end
+              
+                code += "export default [#{code_imports.join(', ')}];"
+
+                { code: code, map: nil }
+              else
+                asset = @environment.find(importee, accept: @input[:content_types].last)
+                if asset
+                  { code: asset.source, map: asset.sourcemap }
+                else
+                  nil
+                end
+              end
+            when 'error'
+              io.write(JSON.generate({rid: message['rid'], return: nil}))
+            
+              case message['args'][0]
+              when 'AssetNotFound'
+                error_message = "Could not find import \"#{message['args'][1]}\" for \"#{message['args'][2]}\".\n\n"
+                error_message << build_tree(message['args'][3], input, message['args'][2])
+                raise exec_runtime_error(error_message)
+              else
+                raise exec_runtime_error(message['args'][0] + ': ' + message['args'][1])
+              end
+            # when 'set_cache'
+            #   @environment.cache.set('rollup', message['args'][0])
+            #   io.write(JSON.generate({rid: message['rid'], return: true}))
+            # when 'get_cache'
+            #   io.write(JSON.generate({rid: message['rid'], return: [(@environment.cache.get('rollup') || '{}')] }))
+            end
+            # puts JSON.generate({rid: message['rid'], return: ret})
+            io.write(JSON.generate({rid: message['rid'], return: ret}))
+          end
         end
+      rescue Errno::EPIPE, EOFError
       end
-      nil
+    
+      io.close
+      if $?.success?
+        true
+      else
+        raise exec_runtime_error(buffer)
+      end
+    end
+
+    def build_tree(renderStack, from, to, visited: nil)
+      visited ||= []
+      return if visited.include?(from)
+      visited << from
+    
+      if renderStack[from].nil? || renderStack[from].empty?
+        nil
+      elsif renderStack[from].include?(to)
+        from
+      else
+        renderStack[from].each do |dep|
+          if tree = build_tree(renderStack, dep, to, visited: visited)
+            return "#{from}\n└ #{tree.lines.each_with_index.map{|l, i| "#{i == 0 ? '' : '    '}#{l}"}.join("")}"
+          end
+        end
+        nil
+      end
     end
   end
-  
 end

--- a/lib/condenser/processors/rollup_processor.rb
+++ b/lib/condenser/processors/rollup_processor.rb
@@ -32,31 +32,35 @@ class Condenser::RollupProcessor
   end
   
   def options
-    {prefix: @prefix, inline: @inline}
+    {prefix: @prefix, dynamic_imports: @dynamic_imports}
   end
   
-  # @param prefix [string] string to prefix to the url of dynamic imports
-  # @param inline [symbol] :inline will inline all the imports in the 
+  # @param prefix  [string] string to prefix to the url of dynamic imports
+  # @param imports [symbol] :inline will inline all the imports in the 
   #                        output file if possible.
-  #                        false will keep all the dynamic import.
+  #                        false will keep all the imports as imports.
   #                        :local will not inline URLS.
-  def initialize(dir = nil, prefix: nil, inline: :imports)
+  # @param dynamic_imports [symbol] Default is :local
+  #    :inline - Inline dynamic imports into the output file if possible.
+  #    :local  - Same as :inline except for URLs are kept as URLs
+  #    :keep   - Keep the dynamic imports but rewrite the import as a URL
+  def initialize(dir = nil, prefix: nil, dynamic_imports: :inline)
     self.class.install_npm_packages(dir)
     @npm_dir = dir
     @prefix = prefix
-    @inline = inline
+    @dynamic_imports = dynamic_imports
   end
 
   def call(environment, input)
-    Runner.new(@npm_dir, prefix: @prefix, inline: @inline).call(environment, input)
+    Runner.new(@npm_dir, prefix: @prefix, dynamic_imports: @dynamic_imports).call(environment, input)
   end
   
   
   class Runner < Condenser::NodeProcessor
-    def initialize(dir = nil, prefix: nil, inline: :imports)
+    def initialize(dir = nil, prefix: nil, dynamic_imports: :inline)
       super(dir)
       @prefix = prefix
-      @inline = inline
+      @dynamic_imports = dynamic_imports
     end
 
     def call(environment, input)
@@ -318,7 +322,6 @@ class Condenser::RollupProcessor
             
               if asset.source_file == @input[:source_file]
                 {
-                  a: 2,
                   path: File.join("/", *[@prefix, asset.path].compact),
                   # source: File.join(@input_dir, asset.filename),
                   source: @entry,
@@ -326,9 +329,8 @@ class Condenser::RollupProcessor
                   # filename: asset.filename
                 }
               else
-                if !@inline
+                if @dynamic_imports != :inline
                   {
-                    a: 1,
                     path: File.join("/", *[@prefix, asset.path].compact),
                     source: File.join(@input_dir, asset.filename),
                     export: true,
@@ -336,7 +338,6 @@ class Condenser::RollupProcessor
                   }
                 else
                   {
-                    a: 3,
                     export: false,
                     source: asset.source_file,
                     filename: asset.filename

--- a/lib/condenser/resolve.rb
+++ b/lib/condenser/resolve.rb
@@ -14,8 +14,14 @@ class Condenser
       @build_cache = BuildCache.new(path, logger: logger)
     end
     
-    def resolve(filename, base=nil, accept: nil)
-      filename = filename.delete_prefix("/") if path.none? { |p| filename.start_with?(p) }
+    def resolve(filename, base=nil, accept: nil, npm: false)
+      search_path = if npm
+        path + [File.join(npm_path, 'node_modules')]
+      else
+        path
+      end
+      
+      filename = filename.delete_prefix("/") if search_path.none? { |p| filename.start_with?(p) }
       dirname, basename, extensions, mime_types = decompose_path(filename, base)
       accept ||= mime_types.empty? ? ['*/*'] : mime_types
       accept = Array(accept)
@@ -28,7 +34,7 @@ class Condenser
           results = []
 
           paths = if dirname&.start_with?('/')
-            if pat = path.find { |pa| dirname.start_with?(pa) }
+            if pat = search_path.find { |pa| dirname.start_with?(pa) }
               dirname.delete_prefix!(pat)
               dirname.delete_prefix!('/')
               [pat]
@@ -36,7 +42,7 @@ class Condenser
               []
             end
           else
-            path
+            search_path
           end
         
           paths.each do |path|
@@ -50,7 +56,7 @@ class Condenser
               if (basename == '*' || basename == f_basename)
                 if accept == ['*/*'] || mime_type_match_accept?(f_mime_types, accept)
                   asset_dir = f_dirname.delete_prefix(path).delete_prefix('/')
-                  asset_basename = f_basename + f_extensions.join('')
+                  asset_basename = f_basename + f_extensions&.join('').to_s
                   asset_filename = asset_dir.empty? ? asset_basename : File.join(asset_dir, asset_basename)
                   results << build_cache.map("#{asset_filename}@#{f_mime_types.join('')}") do
                     Asset.new(self, {
@@ -107,9 +113,9 @@ class Condenser
       end
     end
 
-    def find(filename, base=nil, accept: nil)
+    def find(filename, base=nil, **kargs)
       build do
-        resolve(filename, base, accept: accept).first
+        resolve(filename, base, **kargs).first
       end
     end
     

--- a/lib/condenser/server.rb
+++ b/lib/condenser/server.rb
@@ -69,7 +69,7 @@ class Condenser
       end
 
       # Look up the asset.
-      asset = @condenser.find_export(path)
+      asset = @condenser.find_export(path, npm: true)
       if asset.nil?
         status = :not_found
       elsif fingerprint && asset.etag != fingerprint

--- a/lib/condenser/server.rb
+++ b/lib/condenser/server.rb
@@ -144,39 +144,39 @@ class Condenser
       # Returns a 400 Forbidden response tuple
       def bad_request_response(env)
         if head_request?(env)
-          [ 400, { "Content-Type" => "text/plain", "Content-Length" => "0" }, [] ]
+          [ 400, { "content-type" => "text/plain", "content-length" => "0" }, [] ]
         else
-          [ 400, { "Content-Type" => "text/plain", "Content-Length" => "11" }, [ "Bad Request" ] ]
+          [ 400, { "content-type" => "text/plain", "content-length" => "11" }, [ "Bad Request" ] ]
         end
       end
 
       # Returns a 403 Forbidden response tuple
       def forbidden_response(env)
         if head_request?(env)
-          [ 403, { "Content-Type" => "text/plain", "Content-Length" => "0" }, [] ]
+          [ 403, { "content-type" => "text/plain", "content-length" => "0" }, [] ]
         else
-          [ 403, { "Content-Type" => "text/plain", "Content-Length" => "9" }, [ "Forbidden" ] ]
+          [ 403, { "content-type" => "text/plain", "content-length" => "9" }, [ "Forbidden" ] ]
         end
       end
 
       # Returns a 404 Not Found response tuple
       def not_found_response(env)
         if head_request?(env)
-          [ 404, { "Content-Type" => "text/plain", "Content-Length" => "0", "X-Cascade" => "pass" }, [] ]
+          [ 404, { "content-type" => "text/plain", "content-length" => "0", "x-cascade" => "pass" }, [] ]
         else
-          [ 404, { "Content-Type" => "text/plain", "Content-Length" => "9", "X-Cascade" => "pass" }, [ "Not found" ] ]
+          [ 404, { "content-type" => "text/plain", "content-length" => "9", "x-cascade" => "pass" }, [ "Not found" ] ]
         end
       end
 
       def method_not_allowed_response
-        [ 405, { "Content-Type" => "text/plain", "Content-Length" => "18" }, [ "Method Not Allowed" ] ]
+        [ 405, { "content-type" => "text/plain", "content-length" => "18" }, [ "Method Not Allowed" ] ]
       end
 
       def precondition_failed_response(env)
         if head_request?(env)
-          [ 412, { "Content-Type" => "text/plain", "Content-Length" => "0", "X-Cascade" => "pass" }, [] ]
+          [ 412, { "content-type" => "text/plain", "content-length" => "0", "x-cascade" => "pass" }, [] ]
         else
-          [ 412, { "Content-Type" => "text/plain", "Content-Length" => "19", "X-Cascade" => "pass" }, [ "Precondition Failed" ] ]
+          [ 412, { "content-type" => "text/plain", "content-length" => "19", "x-cascade" => "pass" }, [ "Precondition Failed" ] ]
         end
       end
 
@@ -185,7 +185,7 @@ class Condenser
       def javascript_exception_response(exception)
         err  = "#{exception.class.name}: #{exception.message}\n  (in #{exception.backtrace[0]})"
         body = "throw Error(#{err.inspect})"
-        [ 200, { "Content-Type" => "application/javascript", "Content-Length" => body.bytesize.to_s }, [ body ] ]
+        [ 200, { "content-type" => "application/javascript", "content-length" => body.bytesize.to_s }, [ body ] ]
       end
 
       # Returns a CSS response that hides all elements on the page and
@@ -238,7 +238,7 @@ class Condenser
           }
         CSS
 
-        [ 200, { "Content-Type" => "text/css; charset=utf-8", "Content-Length" => body.bytesize.to_s }, [ body ] ]
+        [ 200, { "content-type" => "text/css; charset=utf-8", "content-length" => body.bytesize.to_s }, [ body ] ]
       end
 
       # Escape special characters for use inside a CSS content("...") string
@@ -254,18 +254,18 @@ class Condenser
         headers = {}
 
         # Set caching headers
-        headers["Cache-Control"] = String.new("public")
-        headers["ETag"]          = %("#{etag}")
+        headers["cache-control"] = String.new("public")
+        headers["etag"]          = %("#{etag}")
 
         # If the request url contains a fingerprint, set a long
         # expires on the response
         if path_fingerprint(env["PATH_INFO"])
-          headers["Cache-Control"] << ", max-age=31536000, immutable"
+          headers["cache-control"] << ", max-age=31536000, immutable"
 
         # Otherwise set `must-revalidate` since the asset could be modified.
         else
-          headers["Cache-Control"] << ", must-revalidate"
-          headers["Vary"] = "Accept-Encoding"
+          headers["cache-control"] << ", must-revalidate"
+          headers["vary"] = "Accept-Encoding"
         end
 
         headers
@@ -275,10 +275,10 @@ class Condenser
         headers = {}
 
         # Set content length header
-        headers["Content-Length"] = length.to_s
+        headers["content-length"] = length.to_s
 
         if asset&.sourcemap
-          headers['SourceMap'] = env['SCRIPT_NAME'] + env['PATH_INFO'] + '.map'
+          headers['sourcemap'] = env['SCRIPT_NAME'] + env['PATH_INFO'] + '.map'
         end
         
         # Set content type header
@@ -287,7 +287,7 @@ class Condenser
           if type.start_with?("text/") && asset.charset
             type += "; charset=#{asset.charset}"
           end
-          headers["Content-Type"] = type
+          headers["content-type"] = type
         end
 
         headers.merge(cache_headers(env, asset.etag))

--- a/lib/condenser/version.rb
+++ b/lib/condenser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Condenser
-  VERSION = '1.4'
+  VERSION = '1.5'
 end

--- a/lib/condenser/version.rb
+++ b/lib/condenser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Condenser
-  VERSION = '1.5'
+  VERSION = '1.5.beta1'
 end

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -86,13 +86,13 @@ class CacheTest < ActiveSupport::TestCase
       }
     JS
 
-    assert_exported_file 'main.js', 'application/javascript', <<~CSS
-      (()=>{var o;console.log((o=5)*o)})();
-    CSS
+    assert_exported_file 'main.js', 'application/javascript', <<~JS
+      function cube(c){return c*c}console.log(cube(5));
+    JS
 
-    assert_exported_file 'main.js', 'application/javascript', <<~CSS
-      (()=>{var o;console.log((o=5)*o)})();
-    CSS
+    assert_exported_file 'main.js', 'application/javascript', <<~JS
+      function cube(c){return c*c}console.log(cube(5));
+    JS
 
     file 'math.js', <<-JS
       export function cube ( x ) {
@@ -101,7 +101,7 @@ class CacheTest < ActiveSupport::TestCase
     JS
 
     assert_exported_file 'main.js', 'application/javascript', <<~CSS
-      (()=>{var o;console.log((o=5)*o*o)})();
+      function cube(c){return c*c*c}console.log(cube(5));
     CSS
   end
 
@@ -281,7 +281,7 @@ class CacheTest < ActiveSupport::TestCase
     JS
 
     assert_exported_file 'a.js', 'application/javascript', <<~JS
-      console.log("a"),console.log("b");
+      function b(){console.log("b")}console.log("a"),b();
     JS
 
     file 'b.js', <<~JS
@@ -289,7 +289,7 @@ class CacheTest < ActiveSupport::TestCase
     JS
 
     assert_exported_file 'a.js', 'application/javascript', <<~JS
-      console.log("a"),console.log("c");
+      function b(){console.log("c")}console.log("a"),b();
     JS
   end
 
@@ -343,7 +343,7 @@ class CacheTest < ActiveSupport::TestCase
     JS
 
     assert_exported_file 'a.js', 'application/javascript', <<~JS
-      console.log("a"),console.log("b"),console.log("c"),console.log("d");
+      function b(){console.log("b")}function d(){console.log("d")}function c(){console.log("c"),d()}console.log("a"),b(),c();
     JS
 
     file 'd.js', "export default function e () { console.log('e'); }\n"
@@ -359,7 +359,7 @@ class CacheTest < ActiveSupport::TestCase
     pd["#{@path}/d.js"].expects(:<<).with { |a| a.source_file == "#{@path}/d.js" }.once
 
     assert_exported_file 'a.js', 'application/javascript', <<~JS
-      console.log("a"),console.log("b"),console.log("c"),console.log("e");
+      function b(){console.log("b")}function e(){console.log("e")}function c(){console.log("c"),e()}console.log("a"),b(),c();
     JS
   end
   
@@ -394,14 +394,14 @@ class CacheTest < ActiveSupport::TestCase
 
     # Set the cache
     env1 = Condenser.new(base1, logger: Logger.new(STDOUT, level: :debug), base: base1, npm_path: @npm_dir, cache: Condenser::Cache::FileStore.new(cachepath))
-    assert_equal 'console.log("a"),console.log("b"),console.log("c");', env1.find('test/a.js').export.source
+    assert_equal 'function c(){console.log("c")}function b(){console.log("b"),c()}console.log("a"),b();', env1.find('test/a.js').export.source
 
     # Poison the cache
     env2 = Condenser.new(base2, logger: Logger.new(STDOUT, level: :debug), base: base2, npm_path: @npm_dir, cache: Condenser::Cache::FileStore.new(cachepath))
-    assert_equal 'console.log("a"),console.log("b"),console.log("d");', env2.find('test/a.js').export.source
+    assert_equal 'function c(){console.log("d")}function b(){console.log("b"),c()}console.log("a"),b();', env2.find('test/a.js').export.source
 
     # Fails to find dependency change because cache is missing the dependency
     env3 = Condenser.new(base3, logger: Logger.new(STDOUT, level: :debug), base: base3, npm_path: @npm_dir, cache: Condenser::Cache::FileStore.new(cachepath))
-    assert_equal 'console.log("a"),console.log("b"),console.log("e");', env3.find('test/a.js').export.source
+    assert_equal 'function c(){console.log("e")}function b(){console.log("b"),c()}console.log("a"),b();', env3.find('test/a.js').export.source
   end
 end

--- a/test/postprocessors/css_media_combiner_test.rb
+++ b/test/postprocessors/css_media_combiner_test.rb
@@ -24,7 +24,7 @@ class MediaCombinerTest < ActiveSupport::TestCase
           display: inline;
         }
       }
-      
+
       .test2{
         display: block;
       }
@@ -35,17 +35,14 @@ class MediaCombinerTest < ActiveSupport::TestCase
       }
     CSS
 
-    assert_exported_file 'main.css', 'text/css', <<~FILE
+    assert_exported_file 'main.css', 'text/css', <<~CSS
     .test{
       display: block;
     }
 
-
-
     .test2{
       display: block;
-    }
-    @media only screen and (max-width: 100px) {
+    }@media only screen and (max-width: 100px) {
       .test {
         display: inline-block;
         color: blue;
@@ -59,7 +56,7 @@ class MediaCombinerTest < ActiveSupport::TestCase
         display: inline;
       }
     }
-    FILE
+    CSS
   end
   
   test 'single line css' do
@@ -67,9 +64,9 @@ class MediaCombinerTest < ActiveSupport::TestCase
       .test{display: block;} @media only screen and (max-width: 100px) {.test {display: inline-block;}}@media only screen and (max-width: 500px) {.test {display: inline;}}.test2{display: block;}@media only screen and (max-width: 100px) {.test2 {display: inline-block;}}
     CSS
 
-    assert_exported_file 'main.css', 'text/css', <<~FILE
-    .test{display: block;} .test2{display: block;}@media only screen and (max-width: 100px) {.test {display: inline-block;}.test2 {display: inline-block;}}@media only screen and (max-width: 500px) {.test {display: inline;}}
-    FILE
+    assert_exported_file 'main.css', 'text/css', <<~CSS
+    .test{display: block;}.test2{display: block;}@media only screen and (max-width: 100px) {.test {display: inline-block;}.test2 {display: inline-block;}}@media only screen and (max-width: 500px) {.test {display: inline;}}
+    CSS
   end
 
 
@@ -88,7 +85,7 @@ class MediaCombinerTest < ActiveSupport::TestCase
     }
     CSS
 
-    assert_exported_file 'main.css', 'text/css', <<~FILE
+    assert_exported_file 'main.css', 'text/css', <<~CSS
     .trobber {
     animation: throb 1s infinite;
     }
@@ -100,7 +97,7 @@ class MediaCombinerTest < ActiveSupport::TestCase
             opacity: 0;
         }
     }
-    FILE
+    CSS
   end
 
 

--- a/test/preprocessor/babel_test.rb
+++ b/test/preprocessor/babel_test.rb
@@ -92,1477 +92,1472 @@ class CondenserBabelTest < ActiveSupport::TestCase
     JS
 
     assert_exported_file 'c.js', 'application/javascript', <<~JS
-      (function () {
-      	'use strict';
-
-      	var commonjsGlobal = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
-
-      	function getDefaultExportFromCjs (x) {
-      		return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
-      	}
-
-      	var es_object_assign = {};
-
-      	var globalThis_1;
-      	var hasRequiredGlobalThis;
-
-      	function requireGlobalThis () {
-      		if (hasRequiredGlobalThis) return globalThis_1;
-      		hasRequiredGlobalThis = 1;
-      		var check = function (it) {
-      		  return it && it.Math === Math && it;
-      		};
-
-      		// https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
-      		globalThis_1 =
-      		  // eslint-disable-next-line es/no-global-this -- safe
-      		  check(typeof globalThis == 'object' && globalThis) ||
-      		  check(typeof window == 'object' && window) ||
-      		  // eslint-disable-next-line no-restricted-globals -- safe
-      		  check(typeof self == 'object' && self) ||
-      		  check(typeof commonjsGlobal == 'object' && commonjsGlobal) ||
-      		  check(typeof globalThis_1 == 'object' && globalThis_1) ||
-      		  // eslint-disable-next-line no-new-func -- fallback
-      		  (function () { return this; })() || Function('return this')();
-      		return globalThis_1;
-      	}
-
-      	var fails;
-      	var hasRequiredFails;
-
-      	function requireFails () {
-      		if (hasRequiredFails) return fails;
-      		hasRequiredFails = 1;
-      		fails = function (exec) {
-      		  try {
-      		    return !!exec();
-      		  } catch (error) {
-      		    return true;
-      		  }
-      		};
-      		return fails;
-      	}
-
-      	var functionBindNative;
-      	var hasRequiredFunctionBindNative;
-
-      	function requireFunctionBindNative () {
-      		if (hasRequiredFunctionBindNative) return functionBindNative;
-      		hasRequiredFunctionBindNative = 1;
-      		var fails = requireFails();
-
-      		functionBindNative = !fails(function () {
-      		  // eslint-disable-next-line es/no-function-prototype-bind -- safe
-      		  var test = (function () { /* empty */ }).bind();
-      		  // eslint-disable-next-line no-prototype-builtins -- safe
-      		  return typeof test != 'function' || test.hasOwnProperty('prototype');
-      		});
-      		return functionBindNative;
-      	}
-
-      	var functionApply;
-      	var hasRequiredFunctionApply;
-
-      	function requireFunctionApply () {
-      		if (hasRequiredFunctionApply) return functionApply;
-      		hasRequiredFunctionApply = 1;
-      		var NATIVE_BIND = requireFunctionBindNative();
-
-      		var FunctionPrototype = Function.prototype;
-      		var apply = FunctionPrototype.apply;
-      		var call = FunctionPrototype.call;
-
-      		// eslint-disable-next-line es/no-function-prototype-bind, es/no-reflect -- safe
-      		functionApply = typeof Reflect == 'object' && Reflect.apply || (NATIVE_BIND ? call.bind(apply) : function () {
-      		  return call.apply(apply, arguments);
-      		});
-      		return functionApply;
-      	}
-
-      	var functionUncurryThis;
-      	var hasRequiredFunctionUncurryThis;
-
-      	function requireFunctionUncurryThis () {
-      		if (hasRequiredFunctionUncurryThis) return functionUncurryThis;
-      		hasRequiredFunctionUncurryThis = 1;
-      		var NATIVE_BIND = requireFunctionBindNative();
-
-      		var FunctionPrototype = Function.prototype;
-      		var call = FunctionPrototype.call;
-      		// eslint-disable-next-line es/no-function-prototype-bind -- safe
-      		var uncurryThisWithBind = NATIVE_BIND && FunctionPrototype.bind.bind(call, call);
-
-      		functionUncurryThis = NATIVE_BIND ? uncurryThisWithBind : function (fn) {
-      		  return function () {
-      		    return call.apply(fn, arguments);
-      		  };
-      		};
-      		return functionUncurryThis;
-      	}
-
-      	var classofRaw;
-      	var hasRequiredClassofRaw;
-
-      	function requireClassofRaw () {
-      		if (hasRequiredClassofRaw) return classofRaw;
-      		hasRequiredClassofRaw = 1;
-      		var uncurryThis = requireFunctionUncurryThis();
-
-      		var toString = uncurryThis({}.toString);
-      		var stringSlice = uncurryThis(''.slice);
-
-      		classofRaw = function (it) {
-      		  return stringSlice(toString(it), 8, -1);
-      		};
-      		return classofRaw;
-      	}
-
-      	var functionUncurryThisClause;
-      	var hasRequiredFunctionUncurryThisClause;
-
-      	function requireFunctionUncurryThisClause () {
-      		if (hasRequiredFunctionUncurryThisClause) return functionUncurryThisClause;
-      		hasRequiredFunctionUncurryThisClause = 1;
-      		var classofRaw = requireClassofRaw();
-      		var uncurryThis = requireFunctionUncurryThis();
-
-      		functionUncurryThisClause = function (fn) {
-      		  // Nashorn bug:
-      		  //   https://github.com/zloirock/core-js/issues/1128
-      		  //   https://github.com/zloirock/core-js/issues/1130
-      		  if (classofRaw(fn) === 'Function') return uncurryThis(fn);
-      		};
-      		return functionUncurryThisClause;
-      	}
-
-      	var isCallable;
-      	var hasRequiredIsCallable;
-
-      	function requireIsCallable () {
-      		if (hasRequiredIsCallable) return isCallable;
-      		hasRequiredIsCallable = 1;
-      		// https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
-      		var documentAll = typeof document == 'object' && document.all;
-
-      		// `IsCallable` abstract operation
-      		// https://tc39.es/ecma262/#sec-iscallable
-      		// eslint-disable-next-line unicorn/no-typeof-undefined -- required for testing
-      		isCallable = typeof documentAll == 'undefined' && documentAll !== undefined ? function (argument) {
-      		  return typeof argument == 'function' || argument === documentAll;
-      		} : function (argument) {
-      		  return typeof argument == 'function';
-      		};
-      		return isCallable;
-      	}
-
-      	var objectGetOwnPropertyDescriptor = {};
-
-      	var descriptors;
-      	var hasRequiredDescriptors;
-
-      	function requireDescriptors () {
-      		if (hasRequiredDescriptors) return descriptors;
-      		hasRequiredDescriptors = 1;
-      		var fails = requireFails();
-
-      		// Detect IE8's incomplete defineProperty implementation
-      		descriptors = !fails(function () {
-      		  // eslint-disable-next-line es/no-object-defineproperty -- required for testing
-      		  return Object.defineProperty({}, 1, { get: function () { return 7; } })[1] !== 7;
-      		});
-      		return descriptors;
-      	}
-
-      	var functionCall;
-      	var hasRequiredFunctionCall;
-
-      	function requireFunctionCall () {
-      		if (hasRequiredFunctionCall) return functionCall;
-      		hasRequiredFunctionCall = 1;
-      		var NATIVE_BIND = requireFunctionBindNative();
-
-      		var call = Function.prototype.call;
-      		// eslint-disable-next-line es/no-function-prototype-bind -- safe
-      		functionCall = NATIVE_BIND ? call.bind(call) : function () {
-      		  return call.apply(call, arguments);
-      		};
-      		return functionCall;
-      	}
-
-      	var objectPropertyIsEnumerable = {};
-
-      	var hasRequiredObjectPropertyIsEnumerable;
-
-      	function requireObjectPropertyIsEnumerable () {
-      		if (hasRequiredObjectPropertyIsEnumerable) return objectPropertyIsEnumerable;
-      		hasRequiredObjectPropertyIsEnumerable = 1;
-      		var $propertyIsEnumerable = {}.propertyIsEnumerable;
-      		// eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
-      		var getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
-
-      		// Nashorn ~ JDK8 bug
-      		var NASHORN_BUG = getOwnPropertyDescriptor && !$propertyIsEnumerable.call({ 1: 2 }, 1);
-
-      		// `Object.prototype.propertyIsEnumerable` method implementation
-      		// https://tc39.es/ecma262/#sec-object.prototype.propertyisenumerable
-      		objectPropertyIsEnumerable.f = NASHORN_BUG ? function propertyIsEnumerable(V) {
-      		  var descriptor = getOwnPropertyDescriptor(this, V);
-      		  return !!descriptor && descriptor.enumerable;
-      		} : $propertyIsEnumerable;
-      		return objectPropertyIsEnumerable;
-      	}
-
-      	var createPropertyDescriptor;
-      	var hasRequiredCreatePropertyDescriptor;
-
-      	function requireCreatePropertyDescriptor () {
-      		if (hasRequiredCreatePropertyDescriptor) return createPropertyDescriptor;
-      		hasRequiredCreatePropertyDescriptor = 1;
-      		createPropertyDescriptor = function (bitmap, value) {
-      		  return {
-      		    enumerable: !(bitmap & 1),
-      		    configurable: !(bitmap & 2),
-      		    writable: !(bitmap & 4),
-      		    value: value
-      		  };
-      		};
-      		return createPropertyDescriptor;
-      	}
-
-      	var indexedObject;
-      	var hasRequiredIndexedObject;
-
-      	function requireIndexedObject () {
-      		if (hasRequiredIndexedObject) return indexedObject;
-      		hasRequiredIndexedObject = 1;
-      		var uncurryThis = requireFunctionUncurryThis();
-      		var fails = requireFails();
-      		var classof = requireClassofRaw();
-
-      		var $Object = Object;
-      		var split = uncurryThis(''.split);
-
-      		// fallback for non-array-like ES3 and non-enumerable old V8 strings
-      		indexedObject = fails(function () {
-      		  // throws an error in rhino, see https://github.com/mozilla/rhino/issues/346
-      		  // eslint-disable-next-line no-prototype-builtins -- safe
-      		  return !$Object('z').propertyIsEnumerable(0);
-      		}) ? function (it) {
-      		  return classof(it) === 'String' ? split(it, '') : $Object(it);
-      		} : $Object;
-      		return indexedObject;
-      	}
-
-      	var isNullOrUndefined;
-      	var hasRequiredIsNullOrUndefined;
-
-      	function requireIsNullOrUndefined () {
-      		if (hasRequiredIsNullOrUndefined) return isNullOrUndefined;
-      		hasRequiredIsNullOrUndefined = 1;
-      		// we can't use just `it == null` since of `document.all` special case
-      		// https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot-aec
-      		isNullOrUndefined = function (it) {
-      		  return it === null || it === undefined;
-      		};
-      		return isNullOrUndefined;
-      	}
-
-      	var requireObjectCoercible;
-      	var hasRequiredRequireObjectCoercible;
-
-      	function requireRequireObjectCoercible () {
-      		if (hasRequiredRequireObjectCoercible) return requireObjectCoercible;
-      		hasRequiredRequireObjectCoercible = 1;
-      		var isNullOrUndefined = requireIsNullOrUndefined();
-
-      		var $TypeError = TypeError;
-
-      		// `RequireObjectCoercible` abstract operation
-      		// https://tc39.es/ecma262/#sec-requireobjectcoercible
-      		requireObjectCoercible = function (it) {
-      		  if (isNullOrUndefined(it)) throw new $TypeError("Can't call method on " + it);
-      		  return it;
-      		};
-      		return requireObjectCoercible;
-      	}
-
-      	var toIndexedObject;
-      	var hasRequiredToIndexedObject;
-
-      	function requireToIndexedObject () {
-      		if (hasRequiredToIndexedObject) return toIndexedObject;
-      		hasRequiredToIndexedObject = 1;
-      		// toObject with fallback for non-array-like ES3 strings
-      		var IndexedObject = requireIndexedObject();
-      		var requireObjectCoercible = requireRequireObjectCoercible();
-
-      		toIndexedObject = function (it) {
-      		  return IndexedObject(requireObjectCoercible(it));
-      		};
-      		return toIndexedObject;
-      	}
-
-      	var isObject;
-      	var hasRequiredIsObject;
-
-      	function requireIsObject () {
-      		if (hasRequiredIsObject) return isObject;
-      		hasRequiredIsObject = 1;
-      		var isCallable = requireIsCallable();
-
-      		isObject = function (it) {
-      		  return typeof it == 'object' ? it !== null : isCallable(it);
-      		};
-      		return isObject;
-      	}
-
-      	var path;
-      	var hasRequiredPath;
-
-      	function requirePath () {
-      		if (hasRequiredPath) return path;
-      		hasRequiredPath = 1;
-      		path = {};
-      		return path;
-      	}
-
-      	var getBuiltIn;
-      	var hasRequiredGetBuiltIn;
-
-      	function requireGetBuiltIn () {
-      		if (hasRequiredGetBuiltIn) return getBuiltIn;
-      		hasRequiredGetBuiltIn = 1;
-      		var path = requirePath();
-      		var globalThis = requireGlobalThis();
-      		var isCallable = requireIsCallable();
-
-      		var aFunction = function (variable) {
-      		  return isCallable(variable) ? variable : undefined;
-      		};
-
-      		getBuiltIn = function (namespace, method) {
-      		  return arguments.length < 2 ? aFunction(path[namespace]) || aFunction(globalThis[namespace])
-      		    : path[namespace] && path[namespace][method] || globalThis[namespace] && globalThis[namespace][method];
-      		};
-      		return getBuiltIn;
-      	}
-
-      	var objectIsPrototypeOf;
-      	var hasRequiredObjectIsPrototypeOf;
-
-      	function requireObjectIsPrototypeOf () {
-      		if (hasRequiredObjectIsPrototypeOf) return objectIsPrototypeOf;
-      		hasRequiredObjectIsPrototypeOf = 1;
-      		var uncurryThis = requireFunctionUncurryThis();
-
-      		objectIsPrototypeOf = uncurryThis({}.isPrototypeOf);
-      		return objectIsPrototypeOf;
-      	}
-
-      	var environmentUserAgent;
-      	var hasRequiredEnvironmentUserAgent;
-
-      	function requireEnvironmentUserAgent () {
-      		if (hasRequiredEnvironmentUserAgent) return environmentUserAgent;
-      		hasRequiredEnvironmentUserAgent = 1;
-      		var globalThis = requireGlobalThis();
-
-      		var navigator = globalThis.navigator;
-      		var userAgent = navigator && navigator.userAgent;
-
-      		environmentUserAgent = userAgent ? String(userAgent) : '';
-      		return environmentUserAgent;
-      	}
-
-      	var environmentV8Version;
-      	var hasRequiredEnvironmentV8Version;
-
-      	function requireEnvironmentV8Version () {
-      		if (hasRequiredEnvironmentV8Version) return environmentV8Version;
-      		hasRequiredEnvironmentV8Version = 1;
-      		var globalThis = requireGlobalThis();
-      		var userAgent = requireEnvironmentUserAgent();
-
-      		var process = globalThis.process;
-      		var Deno = globalThis.Deno;
-      		var versions = process && process.versions || Deno && Deno.version;
-      		var v8 = versions && versions.v8;
-      		var match, version;
-
-      		if (v8) {
-      		  match = v8.split('.');
-      		  // in old Chrome, versions of V8 isn't V8 = Chrome / 10
-      		  // but their correct versions are not interesting for us
-      		  version = match[0] > 0 && match[0] < 4 ? 1 : +(match[0] + match[1]);
-      		}
-
-      		// BrowserFS NodeJS `process` polyfill incorrectly set `.v8` to `0.0`
-      		// so check `userAgent` even if `.v8` exists, but 0
-      		if (!version && userAgent) {
-      		  match = userAgent.match(/Edge\\/(\\d+)/);
-      		  if (!match || match[1] >= 74) {
-      		    match = userAgent.match(/Chrome\\/(\\d+)/);
-      		    if (match) version = +match[1];
-      		  }
-      		}
-
-      		environmentV8Version = version;
-      		return environmentV8Version;
-      	}
-
-      	var symbolConstructorDetection;
-      	var hasRequiredSymbolConstructorDetection;
-
-      	function requireSymbolConstructorDetection () {
-      		if (hasRequiredSymbolConstructorDetection) return symbolConstructorDetection;
-      		hasRequiredSymbolConstructorDetection = 1;
-      		/* eslint-disable es/no-symbol -- required for testing */
-      		var V8_VERSION = requireEnvironmentV8Version();
-      		var fails = requireFails();
-      		var globalThis = requireGlobalThis();
-
-      		var $String = globalThis.String;
-
-      		// eslint-disable-next-line es/no-object-getownpropertysymbols -- required for testing
-      		symbolConstructorDetection = !!Object.getOwnPropertySymbols && !fails(function () {
-      		  var symbol = Symbol('symbol detection');
-      		  // Chrome 38 Symbol has incorrect toString conversion
-      		  // `get-own-property-symbols` polyfill symbols converted to object are not Symbol instances
-      		  // nb: Do not call `String` directly to avoid this being optimized out to `symbol+''` which will,
-      		  // of course, fail.
-      		  return !$String(symbol) || !(Object(symbol) instanceof Symbol) ||
-      		    // Chrome 38-40 symbols are not inherited from DOM collections prototypes to instances
-      		    !Symbol.sham && V8_VERSION && V8_VERSION < 41;
-      		});
-      		return symbolConstructorDetection;
-      	}
-
-      	var useSymbolAsUid;
-      	var hasRequiredUseSymbolAsUid;
-
-      	function requireUseSymbolAsUid () {
-      		if (hasRequiredUseSymbolAsUid) return useSymbolAsUid;
-      		hasRequiredUseSymbolAsUid = 1;
-      		/* eslint-disable es/no-symbol -- required for testing */
-      		var NATIVE_SYMBOL = requireSymbolConstructorDetection();
-
-      		useSymbolAsUid = NATIVE_SYMBOL &&
-      		  !Symbol.sham &&
-      		  typeof Symbol.iterator == 'symbol';
-      		return useSymbolAsUid;
-      	}
-
-      	var isSymbol;
-      	var hasRequiredIsSymbol;
-
-      	function requireIsSymbol () {
-      		if (hasRequiredIsSymbol) return isSymbol;
-      		hasRequiredIsSymbol = 1;
-      		var getBuiltIn = requireGetBuiltIn();
-      		var isCallable = requireIsCallable();
-      		var isPrototypeOf = requireObjectIsPrototypeOf();
-      		var USE_SYMBOL_AS_UID = requireUseSymbolAsUid();
-
-      		var $Object = Object;
-
-      		isSymbol = USE_SYMBOL_AS_UID ? function (it) {
-      		  return typeof it == 'symbol';
-      		} : function (it) {
-      		  var $Symbol = getBuiltIn('Symbol');
-      		  return isCallable($Symbol) && isPrototypeOf($Symbol.prototype, $Object(it));
-      		};
-      		return isSymbol;
-      	}
-
-      	var tryToString;
-      	var hasRequiredTryToString;
-
-      	function requireTryToString () {
-      		if (hasRequiredTryToString) return tryToString;
-      		hasRequiredTryToString = 1;
-      		var $String = String;
-
-      		tryToString = function (argument) {
-      		  try {
-      		    return $String(argument);
-      		  } catch (error) {
-      		    return 'Object';
-      		  }
-      		};
-      		return tryToString;
-      	}
-
-      	var aCallable;
-      	var hasRequiredACallable;
-
-      	function requireACallable () {
-      		if (hasRequiredACallable) return aCallable;
-      		hasRequiredACallable = 1;
-      		var isCallable = requireIsCallable();
-      		var tryToString = requireTryToString();
-
-      		var $TypeError = TypeError;
-
-      		// `Assert: IsCallable(argument) is true`
-      		aCallable = function (argument) {
-      		  if (isCallable(argument)) return argument;
-      		  throw new $TypeError(tryToString(argument) + ' is not a function');
-      		};
-      		return aCallable;
-      	}
-
-      	var getMethod;
-      	var hasRequiredGetMethod;
-
-      	function requireGetMethod () {
-      		if (hasRequiredGetMethod) return getMethod;
-      		hasRequiredGetMethod = 1;
-      		var aCallable = requireACallable();
-      		var isNullOrUndefined = requireIsNullOrUndefined();
-
-      		// `GetMethod` abstract operation
-      		// https://tc39.es/ecma262/#sec-getmethod
-      		getMethod = function (V, P) {
-      		  var func = V[P];
-      		  return isNullOrUndefined(func) ? undefined : aCallable(func);
-      		};
-      		return getMethod;
-      	}
-
-      	var ordinaryToPrimitive;
-      	var hasRequiredOrdinaryToPrimitive;
-
-      	function requireOrdinaryToPrimitive () {
-      		if (hasRequiredOrdinaryToPrimitive) return ordinaryToPrimitive;
-      		hasRequiredOrdinaryToPrimitive = 1;
-      		var call = requireFunctionCall();
-      		var isCallable = requireIsCallable();
-      		var isObject = requireIsObject();
-
-      		var $TypeError = TypeError;
-
-      		// `OrdinaryToPrimitive` abstract operation
-      		// https://tc39.es/ecma262/#sec-ordinarytoprimitive
-      		ordinaryToPrimitive = function (input, pref) {
-      		  var fn, val;
-      		  if (pref === 'string' && isCallable(fn = input.toString) && !isObject(val = call(fn, input))) return val;
-      		  if (isCallable(fn = input.valueOf) && !isObject(val = call(fn, input))) return val;
-      		  if (pref !== 'string' && isCallable(fn = input.toString) && !isObject(val = call(fn, input))) return val;
-      		  throw new $TypeError("Can't convert object to primitive value");
-      		};
-      		return ordinaryToPrimitive;
-      	}
-
-      	var sharedStore = {exports: {}};
-
-      	var isPure;
-      	var hasRequiredIsPure;
-
-      	function requireIsPure () {
-      		if (hasRequiredIsPure) return isPure;
-      		hasRequiredIsPure = 1;
-      		isPure = true;
-      		return isPure;
-      	}
-
-      	var defineGlobalProperty;
-      	var hasRequiredDefineGlobalProperty;
-
-      	function requireDefineGlobalProperty () {
-      		if (hasRequiredDefineGlobalProperty) return defineGlobalProperty;
-      		hasRequiredDefineGlobalProperty = 1;
-      		var globalThis = requireGlobalThis();
-
-      		// eslint-disable-next-line es/no-object-defineproperty -- safe
-      		var defineProperty = Object.defineProperty;
-
-      		defineGlobalProperty = function (key, value) {
-      		  try {
-      		    defineProperty(globalThis, key, { value: value, configurable: true, writable: true });
-      		  } catch (error) {
-      		    globalThis[key] = value;
-      		  } return value;
-      		};
-      		return defineGlobalProperty;
-      	}
-
-      	var hasRequiredSharedStore;
-
-      	function requireSharedStore () {
-      		if (hasRequiredSharedStore) return sharedStore.exports;
-      		hasRequiredSharedStore = 1;
-      		var IS_PURE = requireIsPure();
-      		var globalThis = requireGlobalThis();
-      		var defineGlobalProperty = requireDefineGlobalProperty();
-
-      		var SHARED = '__core-js_shared__';
-      		var store = sharedStore.exports = globalThis[SHARED] || defineGlobalProperty(SHARED, {});
-
-      		(store.versions || (store.versions = [])).push({
-      		  version: '3.42.0',
-      		  mode: IS_PURE ? 'pure' : 'global',
-      		  copyright: '© 2014-2025 Denis Pushkarev (zloirock.ru)',
-      		  license: 'https://github.com/zloirock/core-js/blob/v3.42.0/LICENSE',
-      		  source: 'https://github.com/zloirock/core-js'
-      		});
-      		return sharedStore.exports;
-      	}
-
-      	var shared;
-      	var hasRequiredShared;
-
-      	function requireShared () {
-      		if (hasRequiredShared) return shared;
-      		hasRequiredShared = 1;
-      		var store = requireSharedStore();
-
-      		shared = function (key, value) {
-      		  return store[key] || (store[key] = value || {});
-      		};
-      		return shared;
-      	}
-
-      	var toObject;
-      	var hasRequiredToObject;
-
-      	function requireToObject () {
-      		if (hasRequiredToObject) return toObject;
-      		hasRequiredToObject = 1;
-      		var requireObjectCoercible = requireRequireObjectCoercible();
-
-      		var $Object = Object;
-
-      		// `ToObject` abstract operation
-      		// https://tc39.es/ecma262/#sec-toobject
-      		toObject = function (argument) {
-      		  return $Object(requireObjectCoercible(argument));
-      		};
-      		return toObject;
-      	}
-
-      	var hasOwnProperty_1;
-      	var hasRequiredHasOwnProperty;
-
-      	function requireHasOwnProperty () {
-      		if (hasRequiredHasOwnProperty) return hasOwnProperty_1;
-      		hasRequiredHasOwnProperty = 1;
-      		var uncurryThis = requireFunctionUncurryThis();
-      		var toObject = requireToObject();
-
-      		var hasOwnProperty = uncurryThis({}.hasOwnProperty);
-
-      		// `HasOwnProperty` abstract operation
-      		// https://tc39.es/ecma262/#sec-hasownproperty
-      		// eslint-disable-next-line es/no-object-hasown -- safe
-      		hasOwnProperty_1 = Object.hasOwn || function hasOwn(it, key) {
-      		  return hasOwnProperty(toObject(it), key);
-      		};
-      		return hasOwnProperty_1;
-      	}
-
-      	var uid;
-      	var hasRequiredUid;
-
-      	function requireUid () {
-      		if (hasRequiredUid) return uid;
-      		hasRequiredUid = 1;
-      		var uncurryThis = requireFunctionUncurryThis();
-
-      		var id = 0;
-      		var postfix = Math.random();
-      		var toString = uncurryThis(1.0.toString);
-
-      		uid = function (key) {
-      		  return 'Symbol(' + (key === undefined ? '' : key) + ')_' + toString(++id + postfix, 36);
-      		};
-      		return uid;
-      	}
-
-      	var wellKnownSymbol;
-      	var hasRequiredWellKnownSymbol;
-
-      	function requireWellKnownSymbol () {
-      		if (hasRequiredWellKnownSymbol) return wellKnownSymbol;
-      		hasRequiredWellKnownSymbol = 1;
-      		var globalThis = requireGlobalThis();
-      		var shared = requireShared();
-      		var hasOwn = requireHasOwnProperty();
-      		var uid = requireUid();
-      		var NATIVE_SYMBOL = requireSymbolConstructorDetection();
-      		var USE_SYMBOL_AS_UID = requireUseSymbolAsUid();
-
-      		var Symbol = globalThis.Symbol;
-      		var WellKnownSymbolsStore = shared('wks');
-      		var createWellKnownSymbol = USE_SYMBOL_AS_UID ? Symbol['for'] || Symbol : Symbol && Symbol.withoutSetter || uid;
-
-      		wellKnownSymbol = function (name) {
-      		  if (!hasOwn(WellKnownSymbolsStore, name)) {
-      		    WellKnownSymbolsStore[name] = NATIVE_SYMBOL && hasOwn(Symbol, name)
-      		      ? Symbol[name]
-      		      : createWellKnownSymbol('Symbol.' + name);
-      		  } return WellKnownSymbolsStore[name];
-      		};
-      		return wellKnownSymbol;
-      	}
-
-      	var toPrimitive;
-      	var hasRequiredToPrimitive;
-
-      	function requireToPrimitive () {
-      		if (hasRequiredToPrimitive) return toPrimitive;
-      		hasRequiredToPrimitive = 1;
-      		var call = requireFunctionCall();
-      		var isObject = requireIsObject();
-      		var isSymbol = requireIsSymbol();
-      		var getMethod = requireGetMethod();
-      		var ordinaryToPrimitive = requireOrdinaryToPrimitive();
-      		var wellKnownSymbol = requireWellKnownSymbol();
-
-      		var $TypeError = TypeError;
-      		var TO_PRIMITIVE = wellKnownSymbol('toPrimitive');
-
-      		// `ToPrimitive` abstract operation
-      		// https://tc39.es/ecma262/#sec-toprimitive
-      		toPrimitive = function (input, pref) {
-      		  if (!isObject(input) || isSymbol(input)) return input;
-      		  var exoticToPrim = getMethod(input, TO_PRIMITIVE);
-      		  var result;
-      		  if (exoticToPrim) {
-      		    if (pref === undefined) pref = 'default';
-      		    result = call(exoticToPrim, input, pref);
-      		    if (!isObject(result) || isSymbol(result)) return result;
-      		    throw new $TypeError("Can't convert object to primitive value");
-      		  }
-      		  if (pref === undefined) pref = 'number';
-      		  return ordinaryToPrimitive(input, pref);
-      		};
-      		return toPrimitive;
-      	}
-
-      	var toPropertyKey;
-      	var hasRequiredToPropertyKey;
-
-      	function requireToPropertyKey () {
-      		if (hasRequiredToPropertyKey) return toPropertyKey;
-      		hasRequiredToPropertyKey = 1;
-      		var toPrimitive = requireToPrimitive();
-      		var isSymbol = requireIsSymbol();
-
-      		// `ToPropertyKey` abstract operation
-      		// https://tc39.es/ecma262/#sec-topropertykey
-      		toPropertyKey = function (argument) {
-      		  var key = toPrimitive(argument, 'string');
-      		  return isSymbol(key) ? key : key + '';
-      		};
-      		return toPropertyKey;
-      	}
-
-      	var documentCreateElement;
-      	var hasRequiredDocumentCreateElement;
-
-      	function requireDocumentCreateElement () {
-      		if (hasRequiredDocumentCreateElement) return documentCreateElement;
-      		hasRequiredDocumentCreateElement = 1;
-      		var globalThis = requireGlobalThis();
-      		var isObject = requireIsObject();
-
-      		var document = globalThis.document;
-      		// typeof document.createElement is 'object' in old IE
-      		var EXISTS = isObject(document) && isObject(document.createElement);
-
-      		documentCreateElement = function (it) {
-      		  return EXISTS ? document.createElement(it) : {};
-      		};
-      		return documentCreateElement;
-      	}
-
-      	var ie8DomDefine;
-      	var hasRequiredIe8DomDefine;
-
-      	function requireIe8DomDefine () {
-      		if (hasRequiredIe8DomDefine) return ie8DomDefine;
-      		hasRequiredIe8DomDefine = 1;
-      		var DESCRIPTORS = requireDescriptors();
-      		var fails = requireFails();
-      		var createElement = requireDocumentCreateElement();
-
-      		// Thanks to IE8 for its funny defineProperty
-      		ie8DomDefine = !DESCRIPTORS && !fails(function () {
-      		  // eslint-disable-next-line es/no-object-defineproperty -- required for testing
-      		  return Object.defineProperty(createElement('div'), 'a', {
-      		    get: function () { return 7; }
-      		  }).a !== 7;
-      		});
-      		return ie8DomDefine;
-      	}
-
-      	var hasRequiredObjectGetOwnPropertyDescriptor;
-
-      	function requireObjectGetOwnPropertyDescriptor () {
-      		if (hasRequiredObjectGetOwnPropertyDescriptor) return objectGetOwnPropertyDescriptor;
-      		hasRequiredObjectGetOwnPropertyDescriptor = 1;
-      		var DESCRIPTORS = requireDescriptors();
-      		var call = requireFunctionCall();
-      		var propertyIsEnumerableModule = requireObjectPropertyIsEnumerable();
-      		var createPropertyDescriptor = requireCreatePropertyDescriptor();
-      		var toIndexedObject = requireToIndexedObject();
-      		var toPropertyKey = requireToPropertyKey();
-      		var hasOwn = requireHasOwnProperty();
-      		var IE8_DOM_DEFINE = requireIe8DomDefine();
-
-      		// eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
-      		var $getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
-
-      		// `Object.getOwnPropertyDescriptor` method
-      		// https://tc39.es/ecma262/#sec-object.getownpropertydescriptor
-      		objectGetOwnPropertyDescriptor.f = DESCRIPTORS ? $getOwnPropertyDescriptor : function getOwnPropertyDescriptor(O, P) {
-      		  O = toIndexedObject(O);
-      		  P = toPropertyKey(P);
-      		  if (IE8_DOM_DEFINE) try {
-      		    return $getOwnPropertyDescriptor(O, P);
-      		  } catch (error) { /* empty */ }
-      		  if (hasOwn(O, P)) return createPropertyDescriptor(!call(propertyIsEnumerableModule.f, O, P), O[P]);
-      		};
-      		return objectGetOwnPropertyDescriptor;
-      	}
-
-      	var isForced_1;
-      	var hasRequiredIsForced;
-
-      	function requireIsForced () {
-      		if (hasRequiredIsForced) return isForced_1;
-      		hasRequiredIsForced = 1;
-      		var fails = requireFails();
-      		var isCallable = requireIsCallable();
-
-      		var replacement = /#|\\.prototype\\./;
-
-      		var isForced = function (feature, detection) {
-      		  var value = data[normalize(feature)];
-      		  return value === POLYFILL ? true
-      		    : value === NATIVE ? false
-      		    : isCallable(detection) ? fails(detection)
-      		    : !!detection;
-      		};
-
-      		var normalize = isForced.normalize = function (string) {
-      		  return String(string).replace(replacement, '.').toLowerCase();
-      		};
-
-      		var data = isForced.data = {};
-      		var NATIVE = isForced.NATIVE = 'N';
-      		var POLYFILL = isForced.POLYFILL = 'P';
-
-      		isForced_1 = isForced;
-      		return isForced_1;
-      	}
-
-      	var functionBindContext;
-      	var hasRequiredFunctionBindContext;
-
-      	function requireFunctionBindContext () {
-      		if (hasRequiredFunctionBindContext) return functionBindContext;
-      		hasRequiredFunctionBindContext = 1;
-      		var uncurryThis = requireFunctionUncurryThisClause();
-      		var aCallable = requireACallable();
-      		var NATIVE_BIND = requireFunctionBindNative();
-
-      		var bind = uncurryThis(uncurryThis.bind);
-
-      		// optional / simple context binding
-      		functionBindContext = function (fn, that) {
-      		  aCallable(fn);
-      		  return that === undefined ? fn : NATIVE_BIND ? bind(fn, that) : function (/* ...args */) {
-      		    return fn.apply(that, arguments);
-      		  };
-      		};
-      		return functionBindContext;
-      	}
-
-      	var objectDefineProperty = {};
-
-      	var v8PrototypeDefineBug;
-      	var hasRequiredV8PrototypeDefineBug;
-
-      	function requireV8PrototypeDefineBug () {
-      		if (hasRequiredV8PrototypeDefineBug) return v8PrototypeDefineBug;
-      		hasRequiredV8PrototypeDefineBug = 1;
-      		var DESCRIPTORS = requireDescriptors();
-      		var fails = requireFails();
-
-      		// V8 ~ Chrome 36-
-      		// https://bugs.chromium.org/p/v8/issues/detail?id=3334
-      		v8PrototypeDefineBug = DESCRIPTORS && fails(function () {
-      		  // eslint-disable-next-line es/no-object-defineproperty -- required for testing
-      		  return Object.defineProperty(function () { /* empty */ }, 'prototype', {
-      		    value: 42,
-      		    writable: false
-      		  }).prototype !== 42;
-      		});
-      		return v8PrototypeDefineBug;
-      	}
-
-      	var anObject;
-      	var hasRequiredAnObject;
-
-      	function requireAnObject () {
-      		if (hasRequiredAnObject) return anObject;
-      		hasRequiredAnObject = 1;
-      		var isObject = requireIsObject();
-
-      		var $String = String;
-      		var $TypeError = TypeError;
-
-      		// `Assert: Type(argument) is Object`
-      		anObject = function (argument) {
-      		  if (isObject(argument)) return argument;
-      		  throw new $TypeError($String(argument) + ' is not an object');
-      		};
-      		return anObject;
-      	}
-
-      	var hasRequiredObjectDefineProperty;
-
-      	function requireObjectDefineProperty () {
-      		if (hasRequiredObjectDefineProperty) return objectDefineProperty;
-      		hasRequiredObjectDefineProperty = 1;
-      		var DESCRIPTORS = requireDescriptors();
-      		var IE8_DOM_DEFINE = requireIe8DomDefine();
-      		var V8_PROTOTYPE_DEFINE_BUG = requireV8PrototypeDefineBug();
-      		var anObject = requireAnObject();
-      		var toPropertyKey = requireToPropertyKey();
-
-      		var $TypeError = TypeError;
-      		// eslint-disable-next-line es/no-object-defineproperty -- safe
-      		var $defineProperty = Object.defineProperty;
-      		// eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
-      		var $getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
-      		var ENUMERABLE = 'enumerable';
-      		var CONFIGURABLE = 'configurable';
-      		var WRITABLE = 'writable';
-
-      		// `Object.defineProperty` method
-      		// https://tc39.es/ecma262/#sec-object.defineproperty
-      		objectDefineProperty.f = DESCRIPTORS ? V8_PROTOTYPE_DEFINE_BUG ? function defineProperty(O, P, Attributes) {
-      		  anObject(O);
-      		  P = toPropertyKey(P);
-      		  anObject(Attributes);
-      		  if (typeof O === 'function' && P === 'prototype' && 'value' in Attributes && WRITABLE in Attributes && !Attributes[WRITABLE]) {
-      		    var current = $getOwnPropertyDescriptor(O, P);
-      		    if (current && current[WRITABLE]) {
-      		      O[P] = Attributes.value;
-      		      Attributes = {
-      		        configurable: CONFIGURABLE in Attributes ? Attributes[CONFIGURABLE] : current[CONFIGURABLE],
-      		        enumerable: ENUMERABLE in Attributes ? Attributes[ENUMERABLE] : current[ENUMERABLE],
-      		        writable: false
-      		      };
-      		    }
-      		  } return $defineProperty(O, P, Attributes);
-      		} : $defineProperty : function defineProperty(O, P, Attributes) {
-      		  anObject(O);
-      		  P = toPropertyKey(P);
-      		  anObject(Attributes);
-      		  if (IE8_DOM_DEFINE) try {
-      		    return $defineProperty(O, P, Attributes);
-      		  } catch (error) { /* empty */ }
-      		  if ('get' in Attributes || 'set' in Attributes) throw new $TypeError('Accessors not supported');
-      		  if ('value' in Attributes) O[P] = Attributes.value;
-      		  return O;
-      		};
-      		return objectDefineProperty;
-      	}
-
-      	var createNonEnumerableProperty;
-      	var hasRequiredCreateNonEnumerableProperty;
-
-      	function requireCreateNonEnumerableProperty () {
-      		if (hasRequiredCreateNonEnumerableProperty) return createNonEnumerableProperty;
-      		hasRequiredCreateNonEnumerableProperty = 1;
-      		var DESCRIPTORS = requireDescriptors();
-      		var definePropertyModule = requireObjectDefineProperty();
-      		var createPropertyDescriptor = requireCreatePropertyDescriptor();
-
-      		createNonEnumerableProperty = DESCRIPTORS ? function (object, key, value) {
-      		  return definePropertyModule.f(object, key, createPropertyDescriptor(1, value));
-      		} : function (object, key, value) {
-      		  object[key] = value;
-      		  return object;
-      		};
-      		return createNonEnumerableProperty;
-      	}
-
-      	var _export;
-      	var hasRequired_export;
-
-      	function require_export () {
-      		if (hasRequired_export) return _export;
-      		hasRequired_export = 1;
-      		var globalThis = requireGlobalThis();
-      		var apply = requireFunctionApply();
-      		var uncurryThis = requireFunctionUncurryThisClause();
-      		var isCallable = requireIsCallable();
-      		var getOwnPropertyDescriptor = requireObjectGetOwnPropertyDescriptor().f;
-      		var isForced = requireIsForced();
-      		var path = requirePath();
-      		var bind = requireFunctionBindContext();
-      		var createNonEnumerableProperty = requireCreateNonEnumerableProperty();
-      		var hasOwn = requireHasOwnProperty();
-      		// add debugging info
-      		requireSharedStore();
-
-      		var wrapConstructor = function (NativeConstructor) {
-      		  var Wrapper = function (a, b, c) {
-      		    if (this instanceof Wrapper) {
-      		      switch (arguments.length) {
-      		        case 0: return new NativeConstructor();
-      		        case 1: return new NativeConstructor(a);
-      		        case 2: return new NativeConstructor(a, b);
-      		      } return new NativeConstructor(a, b, c);
-      		    } return apply(NativeConstructor, this, arguments);
-      		  };
-      		  Wrapper.prototype = NativeConstructor.prototype;
-      		  return Wrapper;
-      		};
-
-      		/*
-      		  options.target         - name of the target object
-      		  options.global         - target is the global object
-      		  options.stat           - export as static methods of target
-      		  options.proto          - export as prototype methods of target
-      		  options.real           - real prototype method for the `pure` version
-      		  options.forced         - export even if the native feature is available
-      		  options.bind           - bind methods to the target, required for the `pure` version
-      		  options.wrap           - wrap constructors to preventing global pollution, required for the `pure` version
-      		  options.unsafe         - use the simple assignment of property instead of delete + defineProperty
-      		  options.sham           - add a flag to not completely full polyfills
-      		  options.enumerable     - export as enumerable property
-      		  options.dontCallGetSet - prevent calling a getter on target
-      		  options.name           - the .name of the function if it does not match the key
-      		*/
-      		_export = function (options, source) {
-      		  var TARGET = options.target;
-      		  var GLOBAL = options.global;
-      		  var STATIC = options.stat;
-      		  var PROTO = options.proto;
-
-      		  var nativeSource = GLOBAL ? globalThis : STATIC ? globalThis[TARGET] : globalThis[TARGET] && globalThis[TARGET].prototype;
-
-      		  var target = GLOBAL ? path : path[TARGET] || createNonEnumerableProperty(path, TARGET, {})[TARGET];
-      		  var targetPrototype = target.prototype;
-
-      		  var FORCED, USE_NATIVE, VIRTUAL_PROTOTYPE;
-      		  var key, sourceProperty, targetProperty, nativeProperty, resultProperty, descriptor;
-
-      		  for (key in source) {
-      		    FORCED = isForced(GLOBAL ? key : TARGET + (STATIC ? '.' : '#') + key, options.forced);
-      		    // contains in native
-      		    USE_NATIVE = !FORCED && nativeSource && hasOwn(nativeSource, key);
-
-      		    targetProperty = target[key];
-
-      		    if (USE_NATIVE) if (options.dontCallGetSet) {
-      		      descriptor = getOwnPropertyDescriptor(nativeSource, key);
-      		      nativeProperty = descriptor && descriptor.value;
-      		    } else nativeProperty = nativeSource[key];
-
-      		    // export native or implementation
-      		    sourceProperty = (USE_NATIVE && nativeProperty) ? nativeProperty : source[key];
-
-      		    if (!FORCED && !PROTO && typeof targetProperty == typeof sourceProperty) continue;
-
-      		    // bind methods to global for calling from export context
-      		    if (options.bind && USE_NATIVE) resultProperty = bind(sourceProperty, globalThis);
-      		    // wrap global constructors for prevent changes in this version
-      		    else if (options.wrap && USE_NATIVE) resultProperty = wrapConstructor(sourceProperty);
-      		    // make static versions for prototype methods
-      		    else if (PROTO && isCallable(sourceProperty)) resultProperty = uncurryThis(sourceProperty);
-      		    // default case
-      		    else resultProperty = sourceProperty;
-
-      		    // add a flag to not completely full polyfills
-      		    if (options.sham || (sourceProperty && sourceProperty.sham) || (targetProperty && targetProperty.sham)) {
-      		      createNonEnumerableProperty(resultProperty, 'sham', true);
-      		    }
-
-      		    createNonEnumerableProperty(target, key, resultProperty);
-
-      		    if (PROTO) {
-      		      VIRTUAL_PROTOTYPE = TARGET + 'Prototype';
-      		      if (!hasOwn(path, VIRTUAL_PROTOTYPE)) {
-      		        createNonEnumerableProperty(path, VIRTUAL_PROTOTYPE, {});
-      		      }
-      		      // export virtual prototype methods
-      		      createNonEnumerableProperty(path[VIRTUAL_PROTOTYPE], key, sourceProperty);
-      		      // export real prototype methods
-      		      if (options.real && targetPrototype && (FORCED || !targetPrototype[key])) {
-      		        createNonEnumerableProperty(targetPrototype, key, sourceProperty);
-      		      }
-      		    }
-      		  }
-      		};
-      		return _export;
-      	}
-
-      	var mathTrunc;
-      	var hasRequiredMathTrunc;
-
-      	function requireMathTrunc () {
-      		if (hasRequiredMathTrunc) return mathTrunc;
-      		hasRequiredMathTrunc = 1;
-      		var ceil = Math.ceil;
-      		var floor = Math.floor;
-
-      		// `Math.trunc` method
-      		// https://tc39.es/ecma262/#sec-math.trunc
-      		// eslint-disable-next-line es/no-math-trunc -- safe
-      		mathTrunc = Math.trunc || function trunc(x) {
-      		  var n = +x;
-      		  return (n > 0 ? floor : ceil)(n);
-      		};
-      		return mathTrunc;
-      	}
-
-      	var toIntegerOrInfinity;
-      	var hasRequiredToIntegerOrInfinity;
-
-      	function requireToIntegerOrInfinity () {
-      		if (hasRequiredToIntegerOrInfinity) return toIntegerOrInfinity;
-      		hasRequiredToIntegerOrInfinity = 1;
-      		var trunc = requireMathTrunc();
-
-      		// `ToIntegerOrInfinity` abstract operation
-      		// https://tc39.es/ecma262/#sec-tointegerorinfinity
-      		toIntegerOrInfinity = function (argument) {
-      		  var number = +argument;
-      		  // eslint-disable-next-line no-self-compare -- NaN check
-      		  return number !== number || number === 0 ? 0 : trunc(number);
-      		};
-      		return toIntegerOrInfinity;
-      	}
-
-      	var toAbsoluteIndex;
-      	var hasRequiredToAbsoluteIndex;
-
-      	function requireToAbsoluteIndex () {
-      		if (hasRequiredToAbsoluteIndex) return toAbsoluteIndex;
-      		hasRequiredToAbsoluteIndex = 1;
-      		var toIntegerOrInfinity = requireToIntegerOrInfinity();
-
-      		var max = Math.max;
-      		var min = Math.min;
-
-      		// Helper for a popular repeating case of the spec:
-      		// Let integer be ? ToInteger(index).
-      		// If integer < 0, let result be max((length + integer), 0); else let result be min(integer, length).
-      		toAbsoluteIndex = function (index, length) {
-      		  var integer = toIntegerOrInfinity(index);
-      		  return integer < 0 ? max(integer + length, 0) : min(integer, length);
-      		};
-      		return toAbsoluteIndex;
-      	}
-
-      	var toLength;
-      	var hasRequiredToLength;
-
-      	function requireToLength () {
-      		if (hasRequiredToLength) return toLength;
-      		hasRequiredToLength = 1;
-      		var toIntegerOrInfinity = requireToIntegerOrInfinity();
-
-      		var min = Math.min;
-
-      		// `ToLength` abstract operation
-      		// https://tc39.es/ecma262/#sec-tolength
-      		toLength = function (argument) {
-      		  var len = toIntegerOrInfinity(argument);
-      		  return len > 0 ? min(len, 0x1FFFFFFFFFFFFF) : 0; // 2 ** 53 - 1 == 9007199254740991
-      		};
-      		return toLength;
-      	}
-
-      	var lengthOfArrayLike;
-      	var hasRequiredLengthOfArrayLike;
-
-      	function requireLengthOfArrayLike () {
-      		if (hasRequiredLengthOfArrayLike) return lengthOfArrayLike;
-      		hasRequiredLengthOfArrayLike = 1;
-      		var toLength = requireToLength();
-
-      		// `LengthOfArrayLike` abstract operation
-      		// https://tc39.es/ecma262/#sec-lengthofarraylike
-      		lengthOfArrayLike = function (obj) {
-      		  return toLength(obj.length);
-      		};
-      		return lengthOfArrayLike;
-      	}
-
-      	var arrayIncludes;
-      	var hasRequiredArrayIncludes;
-
-      	function requireArrayIncludes () {
-      		if (hasRequiredArrayIncludes) return arrayIncludes;
-      		hasRequiredArrayIncludes = 1;
-      		var toIndexedObject = requireToIndexedObject();
-      		var toAbsoluteIndex = requireToAbsoluteIndex();
-      		var lengthOfArrayLike = requireLengthOfArrayLike();
-
-      		// `Array.prototype.{ indexOf, includes }` methods implementation
-      		var createMethod = function (IS_INCLUDES) {
-      		  return function ($this, el, fromIndex) {
-      		    var O = toIndexedObject($this);
-      		    var length = lengthOfArrayLike(O);
-      		    if (length === 0) return !IS_INCLUDES && -1;
-      		    var index = toAbsoluteIndex(fromIndex, length);
-      		    var value;
-      		    // Array#includes uses SameValueZero equality algorithm
-      		    // eslint-disable-next-line no-self-compare -- NaN check
-      		    if (IS_INCLUDES && el !== el) while (length > index) {
-      		      value = O[index++];
-      		      // eslint-disable-next-line no-self-compare -- NaN check
-      		      if (value !== value) return true;
-      		    // Array#indexOf ignores holes, Array#includes - not
-      		    } else for (;length > index; index++) {
-      		      if ((IS_INCLUDES || index in O) && O[index] === el) return IS_INCLUDES || index || 0;
-      		    } return !IS_INCLUDES && -1;
-      		  };
-      		};
-
-      		arrayIncludes = {
-      		  // `Array.prototype.includes` method
-      		  // https://tc39.es/ecma262/#sec-array.prototype.includes
-      		  includes: createMethod(true),
-      		  // `Array.prototype.indexOf` method
-      		  // https://tc39.es/ecma262/#sec-array.prototype.indexof
-      		  indexOf: createMethod(false)
-      		};
-      		return arrayIncludes;
-      	}
-
-      	var hiddenKeys;
-      	var hasRequiredHiddenKeys;
-
-      	function requireHiddenKeys () {
-      		if (hasRequiredHiddenKeys) return hiddenKeys;
-      		hasRequiredHiddenKeys = 1;
-      		hiddenKeys = {};
-      		return hiddenKeys;
-      	}
-
-      	var objectKeysInternal;
-      	var hasRequiredObjectKeysInternal;
-
-      	function requireObjectKeysInternal () {
-      		if (hasRequiredObjectKeysInternal) return objectKeysInternal;
-      		hasRequiredObjectKeysInternal = 1;
-      		var uncurryThis = requireFunctionUncurryThis();
-      		var hasOwn = requireHasOwnProperty();
-      		var toIndexedObject = requireToIndexedObject();
-      		var indexOf = requireArrayIncludes().indexOf;
-      		var hiddenKeys = requireHiddenKeys();
-
-      		var push = uncurryThis([].push);
-
-      		objectKeysInternal = function (object, names) {
-      		  var O = toIndexedObject(object);
-      		  var i = 0;
-      		  var result = [];
-      		  var key;
-      		  for (key in O) !hasOwn(hiddenKeys, key) && hasOwn(O, key) && push(result, key);
-      		  // Don't enum bug & hidden keys
-      		  while (names.length > i) if (hasOwn(O, key = names[i++])) {
-      		    ~indexOf(result, key) || push(result, key);
-      		  }
-      		  return result;
-      		};
-      		return objectKeysInternal;
-      	}
-
-      	var enumBugKeys;
-      	var hasRequiredEnumBugKeys;
-
-      	function requireEnumBugKeys () {
-      		if (hasRequiredEnumBugKeys) return enumBugKeys;
-      		hasRequiredEnumBugKeys = 1;
-      		// IE8- don't enum bug keys
-      		enumBugKeys = [
-      		  'constructor',
-      		  'hasOwnProperty',
-      		  'isPrototypeOf',
-      		  'propertyIsEnumerable',
-      		  'toLocaleString',
-      		  'toString',
-      		  'valueOf'
-      		];
-      		return enumBugKeys;
-      	}
-
-      	var objectKeys;
-      	var hasRequiredObjectKeys;
-
-      	function requireObjectKeys () {
-      		if (hasRequiredObjectKeys) return objectKeys;
-      		hasRequiredObjectKeys = 1;
-      		var internalObjectKeys = requireObjectKeysInternal();
-      		var enumBugKeys = requireEnumBugKeys();
-
-      		// `Object.keys` method
-      		// https://tc39.es/ecma262/#sec-object.keys
-      		// eslint-disable-next-line es/no-object-keys -- safe
-      		objectKeys = Object.keys || function keys(O) {
-      		  return internalObjectKeys(O, enumBugKeys);
-      		};
-      		return objectKeys;
-      	}
-
-      	var objectGetOwnPropertySymbols = {};
-
-      	var hasRequiredObjectGetOwnPropertySymbols;
-
-      	function requireObjectGetOwnPropertySymbols () {
-      		if (hasRequiredObjectGetOwnPropertySymbols) return objectGetOwnPropertySymbols;
-      		hasRequiredObjectGetOwnPropertySymbols = 1;
-      		// eslint-disable-next-line es/no-object-getownpropertysymbols -- safe
-      		objectGetOwnPropertySymbols.f = Object.getOwnPropertySymbols;
-      		return objectGetOwnPropertySymbols;
-      	}
-
-      	var objectAssign;
-      	var hasRequiredObjectAssign;
-
-      	function requireObjectAssign () {
-      		if (hasRequiredObjectAssign) return objectAssign;
-      		hasRequiredObjectAssign = 1;
-      		var DESCRIPTORS = requireDescriptors();
-      		var uncurryThis = requireFunctionUncurryThis();
-      		var call = requireFunctionCall();
-      		var fails = requireFails();
-      		var objectKeys = requireObjectKeys();
-      		var getOwnPropertySymbolsModule = requireObjectGetOwnPropertySymbols();
-      		var propertyIsEnumerableModule = requireObjectPropertyIsEnumerable();
-      		var toObject = requireToObject();
-      		var IndexedObject = requireIndexedObject();
-
-      		// eslint-disable-next-line es/no-object-assign -- safe
-      		var $assign = Object.assign;
-      		// eslint-disable-next-line es/no-object-defineproperty -- required for testing
-      		var defineProperty = Object.defineProperty;
-      		var concat = uncurryThis([].concat);
-
-      		// `Object.assign` method
-      		// https://tc39.es/ecma262/#sec-object.assign
-      		objectAssign = !$assign || fails(function () {
-      		  // should have correct order of operations (Edge bug)
-      		  if (DESCRIPTORS && $assign({ b: 1 }, $assign(defineProperty({}, 'a', {
-      		    enumerable: true,
-      		    get: function () {
-      		      defineProperty(this, 'b', {
-      		        value: 3,
-      		        enumerable: false
-      		      });
-      		    }
-      		  }), { b: 2 })).b !== 1) return true;
-      		  // should work with symbols and should have deterministic property order (V8 bug)
-      		  var A = {};
-      		  var B = {};
-      		  // eslint-disable-next-line es/no-symbol -- safe
-      		  var symbol = Symbol('assign detection');
-      		  var alphabet = 'abcdefghijklmnopqrst';
-      		  A[symbol] = 7;
-      		  // eslint-disable-next-line es/no-array-prototype-foreach -- safe
-      		  alphabet.split('').forEach(function (chr) { B[chr] = chr; });
-      		  return $assign({}, A)[symbol] !== 7 || objectKeys($assign({}, B)).join('') !== alphabet;
-      		}) ? function assign(target, source) { // eslint-disable-line no-unused-vars -- required for `.length`
-      		  var T = toObject(target);
-      		  var argumentsLength = arguments.length;
-      		  var index = 1;
-      		  var getOwnPropertySymbols = getOwnPropertySymbolsModule.f;
-      		  var propertyIsEnumerable = propertyIsEnumerableModule.f;
-      		  while (argumentsLength > index) {
-      		    var S = IndexedObject(arguments[index++]);
-      		    var keys = getOwnPropertySymbols ? concat(objectKeys(S), getOwnPropertySymbols(S)) : objectKeys(S);
-      		    var length = keys.length;
-      		    var j = 0;
-      		    var key;
-      		    while (length > j) {
-      		      key = keys[j++];
-      		      if (!DESCRIPTORS || call(propertyIsEnumerable, S, key)) T[key] = S[key];
-      		    }
-      		  } return T;
-      		} : $assign;
-      		return objectAssign;
-      	}
-
-      	var hasRequiredEs_object_assign;
-
-      	function requireEs_object_assign () {
-      		if (hasRequiredEs_object_assign) return es_object_assign;
-      		hasRequiredEs_object_assign = 1;
-      		var $ = require_export();
-      		var assign = requireObjectAssign();
-
-      		// `Object.assign` method
-      		// https://tc39.es/ecma262/#sec-object.assign
-      		// eslint-disable-next-line es/no-object-assign -- required for testing
-      		$({ target: 'Object', stat: true, arity: 2, forced: Object.assign !== assign }, {
-      		  assign: assign
-      		});
-      		return es_object_assign;
-      	}
-
-      	var assign$2;
-      	var hasRequiredAssign$2;
-
-      	function requireAssign$2 () {
-      		if (hasRequiredAssign$2) return assign$2;
-      		hasRequiredAssign$2 = 1;
-      		requireEs_object_assign();
-      		var path = requirePath();
-
-      		assign$2 = path.Object.assign;
-      		return assign$2;
-      	}
-
-      	var assign$1;
-      	var hasRequiredAssign$1;
-
-      	function requireAssign$1 () {
-      		if (hasRequiredAssign$1) return assign$1;
-      		hasRequiredAssign$1 = 1;
-      		var parent = requireAssign$2();
-
-      		assign$1 = parent;
-      		return assign$1;
-      	}
-
-      	var assign;
-      	var hasRequiredAssign;
-
-      	function requireAssign () {
-      		if (hasRequiredAssign) return assign;
-      		hasRequiredAssign = 1;
-      		assign = requireAssign$1();
-      		return assign;
-      	}
-
-      	var assignExports = requireAssign();
-      	var _Object$assign = /*@__PURE__*/getDefaultExportFromCjs(assignExports);
-
-      	function a () {
-      	  console.log(_Object$assign({}, {
-      	    a: 1
-      	  }));
-      	}
-
-      	function b () {
-      	  console.log(_Object$assign({}, {
-      	    b: 1
-      	  }));
-      	}
-
-      	a();
-      	b();
-
-      })();
+      var commonjsGlobal = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
+
+      function getDefaultExportFromCjs (x) {
+      	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+      }
+
+      var es_object_assign = {};
+
+      var globalThis_1;
+      var hasRequiredGlobalThis;
+
+      function requireGlobalThis () {
+      	if (hasRequiredGlobalThis) return globalThis_1;
+      	hasRequiredGlobalThis = 1;
+      	var check = function (it) {
+      	  return it && it.Math === Math && it;
+      	};
+
+      	// https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
+      	globalThis_1 =
+      	  // eslint-disable-next-line es/no-global-this -- safe
+      	  check(typeof globalThis == 'object' && globalThis) ||
+      	  check(typeof window == 'object' && window) ||
+      	  // eslint-disable-next-line no-restricted-globals -- safe
+      	  check(typeof self == 'object' && self) ||
+      	  check(typeof commonjsGlobal == 'object' && commonjsGlobal) ||
+      	  check(typeof globalThis_1 == 'object' && globalThis_1) ||
+      	  // eslint-disable-next-line no-new-func -- fallback
+      	  (function () { return this; })() || Function('return this')();
+      	return globalThis_1;
+      }
+
+      var fails;
+      var hasRequiredFails;
+
+      function requireFails () {
+      	if (hasRequiredFails) return fails;
+      	hasRequiredFails = 1;
+      	fails = function (exec) {
+      	  try {
+      	    return !!exec();
+      	  } catch (error) {
+      	    return true;
+      	  }
+      	};
+      	return fails;
+      }
+
+      var functionBindNative;
+      var hasRequiredFunctionBindNative;
+
+      function requireFunctionBindNative () {
+      	if (hasRequiredFunctionBindNative) return functionBindNative;
+      	hasRequiredFunctionBindNative = 1;
+      	var fails = requireFails();
+
+      	functionBindNative = !fails(function () {
+      	  // eslint-disable-next-line es/no-function-prototype-bind -- safe
+      	  var test = (function () { /* empty */ }).bind();
+      	  // eslint-disable-next-line no-prototype-builtins -- safe
+      	  return typeof test != 'function' || test.hasOwnProperty('prototype');
+      	});
+      	return functionBindNative;
+      }
+
+      var functionApply;
+      var hasRequiredFunctionApply;
+
+      function requireFunctionApply () {
+      	if (hasRequiredFunctionApply) return functionApply;
+      	hasRequiredFunctionApply = 1;
+      	var NATIVE_BIND = requireFunctionBindNative();
+
+      	var FunctionPrototype = Function.prototype;
+      	var apply = FunctionPrototype.apply;
+      	var call = FunctionPrototype.call;
+
+      	// eslint-disable-next-line es/no-function-prototype-bind, es/no-reflect -- safe
+      	functionApply = typeof Reflect == 'object' && Reflect.apply || (NATIVE_BIND ? call.bind(apply) : function () {
+      	  return call.apply(apply, arguments);
+      	});
+      	return functionApply;
+      }
+
+      var functionUncurryThis;
+      var hasRequiredFunctionUncurryThis;
+
+      function requireFunctionUncurryThis () {
+      	if (hasRequiredFunctionUncurryThis) return functionUncurryThis;
+      	hasRequiredFunctionUncurryThis = 1;
+      	var NATIVE_BIND = requireFunctionBindNative();
+
+      	var FunctionPrototype = Function.prototype;
+      	var call = FunctionPrototype.call;
+      	// eslint-disable-next-line es/no-function-prototype-bind -- safe
+      	var uncurryThisWithBind = NATIVE_BIND && FunctionPrototype.bind.bind(call, call);
+
+      	functionUncurryThis = NATIVE_BIND ? uncurryThisWithBind : function (fn) {
+      	  return function () {
+      	    return call.apply(fn, arguments);
+      	  };
+      	};
+      	return functionUncurryThis;
+      }
+
+      var classofRaw;
+      var hasRequiredClassofRaw;
+
+      function requireClassofRaw () {
+      	if (hasRequiredClassofRaw) return classofRaw;
+      	hasRequiredClassofRaw = 1;
+      	var uncurryThis = requireFunctionUncurryThis();
+
+      	var toString = uncurryThis({}.toString);
+      	var stringSlice = uncurryThis(''.slice);
+
+      	classofRaw = function (it) {
+      	  return stringSlice(toString(it), 8, -1);
+      	};
+      	return classofRaw;
+      }
+
+      var functionUncurryThisClause;
+      var hasRequiredFunctionUncurryThisClause;
+
+      function requireFunctionUncurryThisClause () {
+      	if (hasRequiredFunctionUncurryThisClause) return functionUncurryThisClause;
+      	hasRequiredFunctionUncurryThisClause = 1;
+      	var classofRaw = requireClassofRaw();
+      	var uncurryThis = requireFunctionUncurryThis();
+
+      	functionUncurryThisClause = function (fn) {
+      	  // Nashorn bug:
+      	  //   https://github.com/zloirock/core-js/issues/1128
+      	  //   https://github.com/zloirock/core-js/issues/1130
+      	  if (classofRaw(fn) === 'Function') return uncurryThis(fn);
+      	};
+      	return functionUncurryThisClause;
+      }
+
+      var isCallable;
+      var hasRequiredIsCallable;
+
+      function requireIsCallable () {
+      	if (hasRequiredIsCallable) return isCallable;
+      	hasRequiredIsCallable = 1;
+      	// https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
+      	var documentAll = typeof document == 'object' && document.all;
+
+      	// `IsCallable` abstract operation
+      	// https://tc39.es/ecma262/#sec-iscallable
+      	// eslint-disable-next-line unicorn/no-typeof-undefined -- required for testing
+      	isCallable = typeof documentAll == 'undefined' && documentAll !== undefined ? function (argument) {
+      	  return typeof argument == 'function' || argument === documentAll;
+      	} : function (argument) {
+      	  return typeof argument == 'function';
+      	};
+      	return isCallable;
+      }
+
+      var objectGetOwnPropertyDescriptor = {};
+
+      var descriptors;
+      var hasRequiredDescriptors;
+
+      function requireDescriptors () {
+      	if (hasRequiredDescriptors) return descriptors;
+      	hasRequiredDescriptors = 1;
+      	var fails = requireFails();
+
+      	// Detect IE8's incomplete defineProperty implementation
+      	descriptors = !fails(function () {
+      	  // eslint-disable-next-line es/no-object-defineproperty -- required for testing
+      	  return Object.defineProperty({}, 1, { get: function () { return 7; } })[1] !== 7;
+      	});
+      	return descriptors;
+      }
+
+      var functionCall;
+      var hasRequiredFunctionCall;
+
+      function requireFunctionCall () {
+      	if (hasRequiredFunctionCall) return functionCall;
+      	hasRequiredFunctionCall = 1;
+      	var NATIVE_BIND = requireFunctionBindNative();
+
+      	var call = Function.prototype.call;
+      	// eslint-disable-next-line es/no-function-prototype-bind -- safe
+      	functionCall = NATIVE_BIND ? call.bind(call) : function () {
+      	  return call.apply(call, arguments);
+      	};
+      	return functionCall;
+      }
+
+      var objectPropertyIsEnumerable = {};
+
+      var hasRequiredObjectPropertyIsEnumerable;
+
+      function requireObjectPropertyIsEnumerable () {
+      	if (hasRequiredObjectPropertyIsEnumerable) return objectPropertyIsEnumerable;
+      	hasRequiredObjectPropertyIsEnumerable = 1;
+      	var $propertyIsEnumerable = {}.propertyIsEnumerable;
+      	// eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
+      	var getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+
+      	// Nashorn ~ JDK8 bug
+      	var NASHORN_BUG = getOwnPropertyDescriptor && !$propertyIsEnumerable.call({ 1: 2 }, 1);
+
+      	// `Object.prototype.propertyIsEnumerable` method implementation
+      	// https://tc39.es/ecma262/#sec-object.prototype.propertyisenumerable
+      	objectPropertyIsEnumerable.f = NASHORN_BUG ? function propertyIsEnumerable(V) {
+      	  var descriptor = getOwnPropertyDescriptor(this, V);
+      	  return !!descriptor && descriptor.enumerable;
+      	} : $propertyIsEnumerable;
+      	return objectPropertyIsEnumerable;
+      }
+
+      var createPropertyDescriptor;
+      var hasRequiredCreatePropertyDescriptor;
+
+      function requireCreatePropertyDescriptor () {
+      	if (hasRequiredCreatePropertyDescriptor) return createPropertyDescriptor;
+      	hasRequiredCreatePropertyDescriptor = 1;
+      	createPropertyDescriptor = function (bitmap, value) {
+      	  return {
+      	    enumerable: !(bitmap & 1),
+      	    configurable: !(bitmap & 2),
+      	    writable: !(bitmap & 4),
+      	    value: value
+      	  };
+      	};
+      	return createPropertyDescriptor;
+      }
+
+      var indexedObject;
+      var hasRequiredIndexedObject;
+
+      function requireIndexedObject () {
+      	if (hasRequiredIndexedObject) return indexedObject;
+      	hasRequiredIndexedObject = 1;
+      	var uncurryThis = requireFunctionUncurryThis();
+      	var fails = requireFails();
+      	var classof = requireClassofRaw();
+
+      	var $Object = Object;
+      	var split = uncurryThis(''.split);
+
+      	// fallback for non-array-like ES3 and non-enumerable old V8 strings
+      	indexedObject = fails(function () {
+      	  // throws an error in rhino, see https://github.com/mozilla/rhino/issues/346
+      	  // eslint-disable-next-line no-prototype-builtins -- safe
+      	  return !$Object('z').propertyIsEnumerable(0);
+      	}) ? function (it) {
+      	  return classof(it) === 'String' ? split(it, '') : $Object(it);
+      	} : $Object;
+      	return indexedObject;
+      }
+
+      var isNullOrUndefined;
+      var hasRequiredIsNullOrUndefined;
+
+      function requireIsNullOrUndefined () {
+      	if (hasRequiredIsNullOrUndefined) return isNullOrUndefined;
+      	hasRequiredIsNullOrUndefined = 1;
+      	// we can't use just `it == null` since of `document.all` special case
+      	// https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot-aec
+      	isNullOrUndefined = function (it) {
+      	  return it === null || it === undefined;
+      	};
+      	return isNullOrUndefined;
+      }
+
+      var requireObjectCoercible;
+      var hasRequiredRequireObjectCoercible;
+
+      function requireRequireObjectCoercible () {
+      	if (hasRequiredRequireObjectCoercible) return requireObjectCoercible;
+      	hasRequiredRequireObjectCoercible = 1;
+      	var isNullOrUndefined = requireIsNullOrUndefined();
+
+      	var $TypeError = TypeError;
+
+      	// `RequireObjectCoercible` abstract operation
+      	// https://tc39.es/ecma262/#sec-requireobjectcoercible
+      	requireObjectCoercible = function (it) {
+      	  if (isNullOrUndefined(it)) throw new $TypeError("Can't call method on " + it);
+      	  return it;
+      	};
+      	return requireObjectCoercible;
+      }
+
+      var toIndexedObject;
+      var hasRequiredToIndexedObject;
+
+      function requireToIndexedObject () {
+      	if (hasRequiredToIndexedObject) return toIndexedObject;
+      	hasRequiredToIndexedObject = 1;
+      	// toObject with fallback for non-array-like ES3 strings
+      	var IndexedObject = requireIndexedObject();
+      	var requireObjectCoercible = requireRequireObjectCoercible();
+
+      	toIndexedObject = function (it) {
+      	  return IndexedObject(requireObjectCoercible(it));
+      	};
+      	return toIndexedObject;
+      }
+
+      var isObject;
+      var hasRequiredIsObject;
+
+      function requireIsObject () {
+      	if (hasRequiredIsObject) return isObject;
+      	hasRequiredIsObject = 1;
+      	var isCallable = requireIsCallable();
+
+      	isObject = function (it) {
+      	  return typeof it == 'object' ? it !== null : isCallable(it);
+      	};
+      	return isObject;
+      }
+
+      var path;
+      var hasRequiredPath;
+
+      function requirePath () {
+      	if (hasRequiredPath) return path;
+      	hasRequiredPath = 1;
+      	path = {};
+      	return path;
+      }
+
+      var getBuiltIn;
+      var hasRequiredGetBuiltIn;
+
+      function requireGetBuiltIn () {
+      	if (hasRequiredGetBuiltIn) return getBuiltIn;
+      	hasRequiredGetBuiltIn = 1;
+      	var path = requirePath();
+      	var globalThis = requireGlobalThis();
+      	var isCallable = requireIsCallable();
+
+      	var aFunction = function (variable) {
+      	  return isCallable(variable) ? variable : undefined;
+      	};
+
+      	getBuiltIn = function (namespace, method) {
+      	  return arguments.length < 2 ? aFunction(path[namespace]) || aFunction(globalThis[namespace])
+      	    : path[namespace] && path[namespace][method] || globalThis[namespace] && globalThis[namespace][method];
+      	};
+      	return getBuiltIn;
+      }
+
+      var objectIsPrototypeOf;
+      var hasRequiredObjectIsPrototypeOf;
+
+      function requireObjectIsPrototypeOf () {
+      	if (hasRequiredObjectIsPrototypeOf) return objectIsPrototypeOf;
+      	hasRequiredObjectIsPrototypeOf = 1;
+      	var uncurryThis = requireFunctionUncurryThis();
+
+      	objectIsPrototypeOf = uncurryThis({}.isPrototypeOf);
+      	return objectIsPrototypeOf;
+      }
+
+      var environmentUserAgent;
+      var hasRequiredEnvironmentUserAgent;
+
+      function requireEnvironmentUserAgent () {
+      	if (hasRequiredEnvironmentUserAgent) return environmentUserAgent;
+      	hasRequiredEnvironmentUserAgent = 1;
+      	var globalThis = requireGlobalThis();
+
+      	var navigator = globalThis.navigator;
+      	var userAgent = navigator && navigator.userAgent;
+
+      	environmentUserAgent = userAgent ? String(userAgent) : '';
+      	return environmentUserAgent;
+      }
+
+      var environmentV8Version;
+      var hasRequiredEnvironmentV8Version;
+
+      function requireEnvironmentV8Version () {
+      	if (hasRequiredEnvironmentV8Version) return environmentV8Version;
+      	hasRequiredEnvironmentV8Version = 1;
+      	var globalThis = requireGlobalThis();
+      	var userAgent = requireEnvironmentUserAgent();
+
+      	var process = globalThis.process;
+      	var Deno = globalThis.Deno;
+      	var versions = process && process.versions || Deno && Deno.version;
+      	var v8 = versions && versions.v8;
+      	var match, version;
+
+      	if (v8) {
+      	  match = v8.split('.');
+      	  // in old Chrome, versions of V8 isn't V8 = Chrome / 10
+      	  // but their correct versions are not interesting for us
+      	  version = match[0] > 0 && match[0] < 4 ? 1 : +(match[0] + match[1]);
+      	}
+
+      	// BrowserFS NodeJS `process` polyfill incorrectly set `.v8` to `0.0`
+      	// so check `userAgent` even if `.v8` exists, but 0
+      	if (!version && userAgent) {
+      	  match = userAgent.match(/Edge\\/(\\d+)/);
+      	  if (!match || match[1] >= 74) {
+      	    match = userAgent.match(/Chrome\\/(\\d+)/);
+      	    if (match) version = +match[1];
+      	  }
+      	}
+
+      	environmentV8Version = version;
+      	return environmentV8Version;
+      }
+
+      var symbolConstructorDetection;
+      var hasRequiredSymbolConstructorDetection;
+
+      function requireSymbolConstructorDetection () {
+      	if (hasRequiredSymbolConstructorDetection) return symbolConstructorDetection;
+      	hasRequiredSymbolConstructorDetection = 1;
+      	/* eslint-disable es/no-symbol -- required for testing */
+      	var V8_VERSION = requireEnvironmentV8Version();
+      	var fails = requireFails();
+      	var globalThis = requireGlobalThis();
+
+      	var $String = globalThis.String;
+
+      	// eslint-disable-next-line es/no-object-getownpropertysymbols -- required for testing
+      	symbolConstructorDetection = !!Object.getOwnPropertySymbols && !fails(function () {
+      	  var symbol = Symbol('symbol detection');
+      	  // Chrome 38 Symbol has incorrect toString conversion
+      	  // `get-own-property-symbols` polyfill symbols converted to object are not Symbol instances
+      	  // nb: Do not call `String` directly to avoid this being optimized out to `symbol+''` which will,
+      	  // of course, fail.
+      	  return !$String(symbol) || !(Object(symbol) instanceof Symbol) ||
+      	    // Chrome 38-40 symbols are not inherited from DOM collections prototypes to instances
+      	    !Symbol.sham && V8_VERSION && V8_VERSION < 41;
+      	});
+      	return symbolConstructorDetection;
+      }
+
+      var useSymbolAsUid;
+      var hasRequiredUseSymbolAsUid;
+
+      function requireUseSymbolAsUid () {
+      	if (hasRequiredUseSymbolAsUid) return useSymbolAsUid;
+      	hasRequiredUseSymbolAsUid = 1;
+      	/* eslint-disable es/no-symbol -- required for testing */
+      	var NATIVE_SYMBOL = requireSymbolConstructorDetection();
+
+      	useSymbolAsUid = NATIVE_SYMBOL &&
+      	  !Symbol.sham &&
+      	  typeof Symbol.iterator == 'symbol';
+      	return useSymbolAsUid;
+      }
+
+      var isSymbol;
+      var hasRequiredIsSymbol;
+
+      function requireIsSymbol () {
+      	if (hasRequiredIsSymbol) return isSymbol;
+      	hasRequiredIsSymbol = 1;
+      	var getBuiltIn = requireGetBuiltIn();
+      	var isCallable = requireIsCallable();
+      	var isPrototypeOf = requireObjectIsPrototypeOf();
+      	var USE_SYMBOL_AS_UID = requireUseSymbolAsUid();
+
+      	var $Object = Object;
+
+      	isSymbol = USE_SYMBOL_AS_UID ? function (it) {
+      	  return typeof it == 'symbol';
+      	} : function (it) {
+      	  var $Symbol = getBuiltIn('Symbol');
+      	  return isCallable($Symbol) && isPrototypeOf($Symbol.prototype, $Object(it));
+      	};
+      	return isSymbol;
+      }
+
+      var tryToString;
+      var hasRequiredTryToString;
+
+      function requireTryToString () {
+      	if (hasRequiredTryToString) return tryToString;
+      	hasRequiredTryToString = 1;
+      	var $String = String;
+
+      	tryToString = function (argument) {
+      	  try {
+      	    return $String(argument);
+      	  } catch (error) {
+      	    return 'Object';
+      	  }
+      	};
+      	return tryToString;
+      }
+
+      var aCallable;
+      var hasRequiredACallable;
+
+      function requireACallable () {
+      	if (hasRequiredACallable) return aCallable;
+      	hasRequiredACallable = 1;
+      	var isCallable = requireIsCallable();
+      	var tryToString = requireTryToString();
+
+      	var $TypeError = TypeError;
+
+      	// `Assert: IsCallable(argument) is true`
+      	aCallable = function (argument) {
+      	  if (isCallable(argument)) return argument;
+      	  throw new $TypeError(tryToString(argument) + ' is not a function');
+      	};
+      	return aCallable;
+      }
+
+      var getMethod;
+      var hasRequiredGetMethod;
+
+      function requireGetMethod () {
+      	if (hasRequiredGetMethod) return getMethod;
+      	hasRequiredGetMethod = 1;
+      	var aCallable = requireACallable();
+      	var isNullOrUndefined = requireIsNullOrUndefined();
+
+      	// `GetMethod` abstract operation
+      	// https://tc39.es/ecma262/#sec-getmethod
+      	getMethod = function (V, P) {
+      	  var func = V[P];
+      	  return isNullOrUndefined(func) ? undefined : aCallable(func);
+      	};
+      	return getMethod;
+      }
+
+      var ordinaryToPrimitive;
+      var hasRequiredOrdinaryToPrimitive;
+
+      function requireOrdinaryToPrimitive () {
+      	if (hasRequiredOrdinaryToPrimitive) return ordinaryToPrimitive;
+      	hasRequiredOrdinaryToPrimitive = 1;
+      	var call = requireFunctionCall();
+      	var isCallable = requireIsCallable();
+      	var isObject = requireIsObject();
+
+      	var $TypeError = TypeError;
+
+      	// `OrdinaryToPrimitive` abstract operation
+      	// https://tc39.es/ecma262/#sec-ordinarytoprimitive
+      	ordinaryToPrimitive = function (input, pref) {
+      	  var fn, val;
+      	  if (pref === 'string' && isCallable(fn = input.toString) && !isObject(val = call(fn, input))) return val;
+      	  if (isCallable(fn = input.valueOf) && !isObject(val = call(fn, input))) return val;
+      	  if (pref !== 'string' && isCallable(fn = input.toString) && !isObject(val = call(fn, input))) return val;
+      	  throw new $TypeError("Can't convert object to primitive value");
+      	};
+      	return ordinaryToPrimitive;
+      }
+
+      var sharedStore = {exports: {}};
+
+      var isPure;
+      var hasRequiredIsPure;
+
+      function requireIsPure () {
+      	if (hasRequiredIsPure) return isPure;
+      	hasRequiredIsPure = 1;
+      	isPure = true;
+      	return isPure;
+      }
+
+      var defineGlobalProperty;
+      var hasRequiredDefineGlobalProperty;
+
+      function requireDefineGlobalProperty () {
+      	if (hasRequiredDefineGlobalProperty) return defineGlobalProperty;
+      	hasRequiredDefineGlobalProperty = 1;
+      	var globalThis = requireGlobalThis();
+
+      	// eslint-disable-next-line es/no-object-defineproperty -- safe
+      	var defineProperty = Object.defineProperty;
+
+      	defineGlobalProperty = function (key, value) {
+      	  try {
+      	    defineProperty(globalThis, key, { value: value, configurable: true, writable: true });
+      	  } catch (error) {
+      	    globalThis[key] = value;
+      	  } return value;
+      	};
+      	return defineGlobalProperty;
+      }
+
+      var hasRequiredSharedStore;
+
+      function requireSharedStore () {
+      	if (hasRequiredSharedStore) return sharedStore.exports;
+      	hasRequiredSharedStore = 1;
+      	var IS_PURE = requireIsPure();
+      	var globalThis = requireGlobalThis();
+      	var defineGlobalProperty = requireDefineGlobalProperty();
+
+      	var SHARED = '__core-js_shared__';
+      	var store = sharedStore.exports = globalThis[SHARED] || defineGlobalProperty(SHARED, {});
+
+      	(store.versions || (store.versions = [])).push({
+      	  version: '3.44.0',
+      	  mode: IS_PURE ? 'pure' : 'global',
+      	  copyright: '© 2014-2025 Denis Pushkarev (zloirock.ru)',
+      	  license: 'https://github.com/zloirock/core-js/blob/v3.44.0/LICENSE',
+      	  source: 'https://github.com/zloirock/core-js'
+      	});
+      	return sharedStore.exports;
+      }
+
+      var shared;
+      var hasRequiredShared;
+
+      function requireShared () {
+      	if (hasRequiredShared) return shared;
+      	hasRequiredShared = 1;
+      	var store = requireSharedStore();
+
+      	shared = function (key, value) {
+      	  return store[key] || (store[key] = value || {});
+      	};
+      	return shared;
+      }
+
+      var toObject;
+      var hasRequiredToObject;
+
+      function requireToObject () {
+      	if (hasRequiredToObject) return toObject;
+      	hasRequiredToObject = 1;
+      	var requireObjectCoercible = requireRequireObjectCoercible();
+
+      	var $Object = Object;
+
+      	// `ToObject` abstract operation
+      	// https://tc39.es/ecma262/#sec-toobject
+      	toObject = function (argument) {
+      	  return $Object(requireObjectCoercible(argument));
+      	};
+      	return toObject;
+      }
+
+      var hasOwnProperty_1;
+      var hasRequiredHasOwnProperty;
+
+      function requireHasOwnProperty () {
+      	if (hasRequiredHasOwnProperty) return hasOwnProperty_1;
+      	hasRequiredHasOwnProperty = 1;
+      	var uncurryThis = requireFunctionUncurryThis();
+      	var toObject = requireToObject();
+
+      	var hasOwnProperty = uncurryThis({}.hasOwnProperty);
+
+      	// `HasOwnProperty` abstract operation
+      	// https://tc39.es/ecma262/#sec-hasownproperty
+      	// eslint-disable-next-line es/no-object-hasown -- safe
+      	hasOwnProperty_1 = Object.hasOwn || function hasOwn(it, key) {
+      	  return hasOwnProperty(toObject(it), key);
+      	};
+      	return hasOwnProperty_1;
+      }
+
+      var uid;
+      var hasRequiredUid;
+
+      function requireUid () {
+      	if (hasRequiredUid) return uid;
+      	hasRequiredUid = 1;
+      	var uncurryThis = requireFunctionUncurryThis();
+
+      	var id = 0;
+      	var postfix = Math.random();
+      	var toString = uncurryThis(1.1.toString);
+
+      	uid = function (key) {
+      	  return 'Symbol(' + (key === undefined ? '' : key) + ')_' + toString(++id + postfix, 36);
+      	};
+      	return uid;
+      }
+
+      var wellKnownSymbol;
+      var hasRequiredWellKnownSymbol;
+
+      function requireWellKnownSymbol () {
+      	if (hasRequiredWellKnownSymbol) return wellKnownSymbol;
+      	hasRequiredWellKnownSymbol = 1;
+      	var globalThis = requireGlobalThis();
+      	var shared = requireShared();
+      	var hasOwn = requireHasOwnProperty();
+      	var uid = requireUid();
+      	var NATIVE_SYMBOL = requireSymbolConstructorDetection();
+      	var USE_SYMBOL_AS_UID = requireUseSymbolAsUid();
+
+      	var Symbol = globalThis.Symbol;
+      	var WellKnownSymbolsStore = shared('wks');
+      	var createWellKnownSymbol = USE_SYMBOL_AS_UID ? Symbol['for'] || Symbol : Symbol && Symbol.withoutSetter || uid;
+
+      	wellKnownSymbol = function (name) {
+      	  if (!hasOwn(WellKnownSymbolsStore, name)) {
+      	    WellKnownSymbolsStore[name] = NATIVE_SYMBOL && hasOwn(Symbol, name)
+      	      ? Symbol[name]
+      	      : createWellKnownSymbol('Symbol.' + name);
+      	  } return WellKnownSymbolsStore[name];
+      	};
+      	return wellKnownSymbol;
+      }
+
+      var toPrimitive;
+      var hasRequiredToPrimitive;
+
+      function requireToPrimitive () {
+      	if (hasRequiredToPrimitive) return toPrimitive;
+      	hasRequiredToPrimitive = 1;
+      	var call = requireFunctionCall();
+      	var isObject = requireIsObject();
+      	var isSymbol = requireIsSymbol();
+      	var getMethod = requireGetMethod();
+      	var ordinaryToPrimitive = requireOrdinaryToPrimitive();
+      	var wellKnownSymbol = requireWellKnownSymbol();
+
+      	var $TypeError = TypeError;
+      	var TO_PRIMITIVE = wellKnownSymbol('toPrimitive');
+
+      	// `ToPrimitive` abstract operation
+      	// https://tc39.es/ecma262/#sec-toprimitive
+      	toPrimitive = function (input, pref) {
+      	  if (!isObject(input) || isSymbol(input)) return input;
+      	  var exoticToPrim = getMethod(input, TO_PRIMITIVE);
+      	  var result;
+      	  if (exoticToPrim) {
+      	    if (pref === undefined) pref = 'default';
+      	    result = call(exoticToPrim, input, pref);
+      	    if (!isObject(result) || isSymbol(result)) return result;
+      	    throw new $TypeError("Can't convert object to primitive value");
+      	  }
+      	  if (pref === undefined) pref = 'number';
+      	  return ordinaryToPrimitive(input, pref);
+      	};
+      	return toPrimitive;
+      }
+
+      var toPropertyKey;
+      var hasRequiredToPropertyKey;
+
+      function requireToPropertyKey () {
+      	if (hasRequiredToPropertyKey) return toPropertyKey;
+      	hasRequiredToPropertyKey = 1;
+      	var toPrimitive = requireToPrimitive();
+      	var isSymbol = requireIsSymbol();
+
+      	// `ToPropertyKey` abstract operation
+      	// https://tc39.es/ecma262/#sec-topropertykey
+      	toPropertyKey = function (argument) {
+      	  var key = toPrimitive(argument, 'string');
+      	  return isSymbol(key) ? key : key + '';
+      	};
+      	return toPropertyKey;
+      }
+
+      var documentCreateElement;
+      var hasRequiredDocumentCreateElement;
+
+      function requireDocumentCreateElement () {
+      	if (hasRequiredDocumentCreateElement) return documentCreateElement;
+      	hasRequiredDocumentCreateElement = 1;
+      	var globalThis = requireGlobalThis();
+      	var isObject = requireIsObject();
+
+      	var document = globalThis.document;
+      	// typeof document.createElement is 'object' in old IE
+      	var EXISTS = isObject(document) && isObject(document.createElement);
+
+      	documentCreateElement = function (it) {
+      	  return EXISTS ? document.createElement(it) : {};
+      	};
+      	return documentCreateElement;
+      }
+
+      var ie8DomDefine;
+      var hasRequiredIe8DomDefine;
+
+      function requireIe8DomDefine () {
+      	if (hasRequiredIe8DomDefine) return ie8DomDefine;
+      	hasRequiredIe8DomDefine = 1;
+      	var DESCRIPTORS = requireDescriptors();
+      	var fails = requireFails();
+      	var createElement = requireDocumentCreateElement();
+
+      	// Thanks to IE8 for its funny defineProperty
+      	ie8DomDefine = !DESCRIPTORS && !fails(function () {
+      	  // eslint-disable-next-line es/no-object-defineproperty -- required for testing
+      	  return Object.defineProperty(createElement('div'), 'a', {
+      	    get: function () { return 7; }
+      	  }).a !== 7;
+      	});
+      	return ie8DomDefine;
+      }
+
+      var hasRequiredObjectGetOwnPropertyDescriptor;
+
+      function requireObjectGetOwnPropertyDescriptor () {
+      	if (hasRequiredObjectGetOwnPropertyDescriptor) return objectGetOwnPropertyDescriptor;
+      	hasRequiredObjectGetOwnPropertyDescriptor = 1;
+      	var DESCRIPTORS = requireDescriptors();
+      	var call = requireFunctionCall();
+      	var propertyIsEnumerableModule = requireObjectPropertyIsEnumerable();
+      	var createPropertyDescriptor = requireCreatePropertyDescriptor();
+      	var toIndexedObject = requireToIndexedObject();
+      	var toPropertyKey = requireToPropertyKey();
+      	var hasOwn = requireHasOwnProperty();
+      	var IE8_DOM_DEFINE = requireIe8DomDefine();
+
+      	// eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
+      	var $getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+
+      	// `Object.getOwnPropertyDescriptor` method
+      	// https://tc39.es/ecma262/#sec-object.getownpropertydescriptor
+      	objectGetOwnPropertyDescriptor.f = DESCRIPTORS ? $getOwnPropertyDescriptor : function getOwnPropertyDescriptor(O, P) {
+      	  O = toIndexedObject(O);
+      	  P = toPropertyKey(P);
+      	  if (IE8_DOM_DEFINE) try {
+      	    return $getOwnPropertyDescriptor(O, P);
+      	  } catch (error) { /* empty */ }
+      	  if (hasOwn(O, P)) return createPropertyDescriptor(!call(propertyIsEnumerableModule.f, O, P), O[P]);
+      	};
+      	return objectGetOwnPropertyDescriptor;
+      }
+
+      var isForced_1;
+      var hasRequiredIsForced;
+
+      function requireIsForced () {
+      	if (hasRequiredIsForced) return isForced_1;
+      	hasRequiredIsForced = 1;
+      	var fails = requireFails();
+      	var isCallable = requireIsCallable();
+
+      	var replacement = /#|\\.prototype\\./;
+
+      	var isForced = function (feature, detection) {
+      	  var value = data[normalize(feature)];
+      	  return value === POLYFILL ? true
+      	    : value === NATIVE ? false
+      	    : isCallable(detection) ? fails(detection)
+      	    : !!detection;
+      	};
+
+      	var normalize = isForced.normalize = function (string) {
+      	  return String(string).replace(replacement, '.').toLowerCase();
+      	};
+
+      	var data = isForced.data = {};
+      	var NATIVE = isForced.NATIVE = 'N';
+      	var POLYFILL = isForced.POLYFILL = 'P';
+
+      	isForced_1 = isForced;
+      	return isForced_1;
+      }
+
+      var functionBindContext;
+      var hasRequiredFunctionBindContext;
+
+      function requireFunctionBindContext () {
+      	if (hasRequiredFunctionBindContext) return functionBindContext;
+      	hasRequiredFunctionBindContext = 1;
+      	var uncurryThis = requireFunctionUncurryThisClause();
+      	var aCallable = requireACallable();
+      	var NATIVE_BIND = requireFunctionBindNative();
+
+      	var bind = uncurryThis(uncurryThis.bind);
+
+      	// optional / simple context binding
+      	functionBindContext = function (fn, that) {
+      	  aCallable(fn);
+      	  return that === undefined ? fn : NATIVE_BIND ? bind(fn, that) : function (/* ...args */) {
+      	    return fn.apply(that, arguments);
+      	  };
+      	};
+      	return functionBindContext;
+      }
+
+      var objectDefineProperty = {};
+
+      var v8PrototypeDefineBug;
+      var hasRequiredV8PrototypeDefineBug;
+
+      function requireV8PrototypeDefineBug () {
+      	if (hasRequiredV8PrototypeDefineBug) return v8PrototypeDefineBug;
+      	hasRequiredV8PrototypeDefineBug = 1;
+      	var DESCRIPTORS = requireDescriptors();
+      	var fails = requireFails();
+
+      	// V8 ~ Chrome 36-
+      	// https://bugs.chromium.org/p/v8/issues/detail?id=3334
+      	v8PrototypeDefineBug = DESCRIPTORS && fails(function () {
+      	  // eslint-disable-next-line es/no-object-defineproperty -- required for testing
+      	  return Object.defineProperty(function () { /* empty */ }, 'prototype', {
+      	    value: 42,
+      	    writable: false
+      	  }).prototype !== 42;
+      	});
+      	return v8PrototypeDefineBug;
+      }
+
+      var anObject;
+      var hasRequiredAnObject;
+
+      function requireAnObject () {
+      	if (hasRequiredAnObject) return anObject;
+      	hasRequiredAnObject = 1;
+      	var isObject = requireIsObject();
+
+      	var $String = String;
+      	var $TypeError = TypeError;
+
+      	// `Assert: Type(argument) is Object`
+      	anObject = function (argument) {
+      	  if (isObject(argument)) return argument;
+      	  throw new $TypeError($String(argument) + ' is not an object');
+      	};
+      	return anObject;
+      }
+
+      var hasRequiredObjectDefineProperty;
+
+      function requireObjectDefineProperty () {
+      	if (hasRequiredObjectDefineProperty) return objectDefineProperty;
+      	hasRequiredObjectDefineProperty = 1;
+      	var DESCRIPTORS = requireDescriptors();
+      	var IE8_DOM_DEFINE = requireIe8DomDefine();
+      	var V8_PROTOTYPE_DEFINE_BUG = requireV8PrototypeDefineBug();
+      	var anObject = requireAnObject();
+      	var toPropertyKey = requireToPropertyKey();
+
+      	var $TypeError = TypeError;
+      	// eslint-disable-next-line es/no-object-defineproperty -- safe
+      	var $defineProperty = Object.defineProperty;
+      	// eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
+      	var $getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+      	var ENUMERABLE = 'enumerable';
+      	var CONFIGURABLE = 'configurable';
+      	var WRITABLE = 'writable';
+
+      	// `Object.defineProperty` method
+      	// https://tc39.es/ecma262/#sec-object.defineproperty
+      	objectDefineProperty.f = DESCRIPTORS ? V8_PROTOTYPE_DEFINE_BUG ? function defineProperty(O, P, Attributes) {
+      	  anObject(O);
+      	  P = toPropertyKey(P);
+      	  anObject(Attributes);
+      	  if (typeof O === 'function' && P === 'prototype' && 'value' in Attributes && WRITABLE in Attributes && !Attributes[WRITABLE]) {
+      	    var current = $getOwnPropertyDescriptor(O, P);
+      	    if (current && current[WRITABLE]) {
+      	      O[P] = Attributes.value;
+      	      Attributes = {
+      	        configurable: CONFIGURABLE in Attributes ? Attributes[CONFIGURABLE] : current[CONFIGURABLE],
+      	        enumerable: ENUMERABLE in Attributes ? Attributes[ENUMERABLE] : current[ENUMERABLE],
+      	        writable: false
+      	      };
+      	    }
+      	  } return $defineProperty(O, P, Attributes);
+      	} : $defineProperty : function defineProperty(O, P, Attributes) {
+      	  anObject(O);
+      	  P = toPropertyKey(P);
+      	  anObject(Attributes);
+      	  if (IE8_DOM_DEFINE) try {
+      	    return $defineProperty(O, P, Attributes);
+      	  } catch (error) { /* empty */ }
+      	  if ('get' in Attributes || 'set' in Attributes) throw new $TypeError('Accessors not supported');
+      	  if ('value' in Attributes) O[P] = Attributes.value;
+      	  return O;
+      	};
+      	return objectDefineProperty;
+      }
+
+      var createNonEnumerableProperty;
+      var hasRequiredCreateNonEnumerableProperty;
+
+      function requireCreateNonEnumerableProperty () {
+      	if (hasRequiredCreateNonEnumerableProperty) return createNonEnumerableProperty;
+      	hasRequiredCreateNonEnumerableProperty = 1;
+      	var DESCRIPTORS = requireDescriptors();
+      	var definePropertyModule = requireObjectDefineProperty();
+      	var createPropertyDescriptor = requireCreatePropertyDescriptor();
+
+      	createNonEnumerableProperty = DESCRIPTORS ? function (object, key, value) {
+      	  return definePropertyModule.f(object, key, createPropertyDescriptor(1, value));
+      	} : function (object, key, value) {
+      	  object[key] = value;
+      	  return object;
+      	};
+      	return createNonEnumerableProperty;
+      }
+
+      var _export;
+      var hasRequired_export;
+
+      function require_export () {
+      	if (hasRequired_export) return _export;
+      	hasRequired_export = 1;
+      	var globalThis = requireGlobalThis();
+      	var apply = requireFunctionApply();
+      	var uncurryThis = requireFunctionUncurryThisClause();
+      	var isCallable = requireIsCallable();
+      	var getOwnPropertyDescriptor = requireObjectGetOwnPropertyDescriptor().f;
+      	var isForced = requireIsForced();
+      	var path = requirePath();
+      	var bind = requireFunctionBindContext();
+      	var createNonEnumerableProperty = requireCreateNonEnumerableProperty();
+      	var hasOwn = requireHasOwnProperty();
+      	// add debugging info
+      	requireSharedStore();
+
+      	var wrapConstructor = function (NativeConstructor) {
+      	  var Wrapper = function (a, b, c) {
+      	    if (this instanceof Wrapper) {
+      	      switch (arguments.length) {
+      	        case 0: return new NativeConstructor();
+      	        case 1: return new NativeConstructor(a);
+      	        case 2: return new NativeConstructor(a, b);
+      	      } return new NativeConstructor(a, b, c);
+      	    } return apply(NativeConstructor, this, arguments);
+      	  };
+      	  Wrapper.prototype = NativeConstructor.prototype;
+      	  return Wrapper;
+      	};
+
+      	/*
+      	  options.target         - name of the target object
+      	  options.global         - target is the global object
+      	  options.stat           - export as static methods of target
+      	  options.proto          - export as prototype methods of target
+      	  options.real           - real prototype method for the `pure` version
+      	  options.forced         - export even if the native feature is available
+      	  options.bind           - bind methods to the target, required for the `pure` version
+      	  options.wrap           - wrap constructors to preventing global pollution, required for the `pure` version
+      	  options.unsafe         - use the simple assignment of property instead of delete + defineProperty
+      	  options.sham           - add a flag to not completely full polyfills
+      	  options.enumerable     - export as enumerable property
+      	  options.dontCallGetSet - prevent calling a getter on target
+      	  options.name           - the .name of the function if it does not match the key
+      	*/
+      	_export = function (options, source) {
+      	  var TARGET = options.target;
+      	  var GLOBAL = options.global;
+      	  var STATIC = options.stat;
+      	  var PROTO = options.proto;
+
+      	  var nativeSource = GLOBAL ? globalThis : STATIC ? globalThis[TARGET] : globalThis[TARGET] && globalThis[TARGET].prototype;
+
+      	  var target = GLOBAL ? path : path[TARGET] || createNonEnumerableProperty(path, TARGET, {})[TARGET];
+      	  var targetPrototype = target.prototype;
+
+      	  var FORCED, USE_NATIVE, VIRTUAL_PROTOTYPE;
+      	  var key, sourceProperty, targetProperty, nativeProperty, resultProperty, descriptor;
+
+      	  for (key in source) {
+      	    FORCED = isForced(GLOBAL ? key : TARGET + (STATIC ? '.' : '#') + key, options.forced);
+      	    // contains in native
+      	    USE_NATIVE = !FORCED && nativeSource && hasOwn(nativeSource, key);
+
+      	    targetProperty = target[key];
+
+      	    if (USE_NATIVE) if (options.dontCallGetSet) {
+      	      descriptor = getOwnPropertyDescriptor(nativeSource, key);
+      	      nativeProperty = descriptor && descriptor.value;
+      	    } else nativeProperty = nativeSource[key];
+
+      	    // export native or implementation
+      	    sourceProperty = (USE_NATIVE && nativeProperty) ? nativeProperty : source[key];
+
+      	    if (!FORCED && !PROTO && typeof targetProperty == typeof sourceProperty) continue;
+
+      	    // bind methods to global for calling from export context
+      	    if (options.bind && USE_NATIVE) resultProperty = bind(sourceProperty, globalThis);
+      	    // wrap global constructors for prevent changes in this version
+      	    else if (options.wrap && USE_NATIVE) resultProperty = wrapConstructor(sourceProperty);
+      	    // make static versions for prototype methods
+      	    else if (PROTO && isCallable(sourceProperty)) resultProperty = uncurryThis(sourceProperty);
+      	    // default case
+      	    else resultProperty = sourceProperty;
+
+      	    // add a flag to not completely full polyfills
+      	    if (options.sham || (sourceProperty && sourceProperty.sham) || (targetProperty && targetProperty.sham)) {
+      	      createNonEnumerableProperty(resultProperty, 'sham', true);
+      	    }
+
+      	    createNonEnumerableProperty(target, key, resultProperty);
+
+      	    if (PROTO) {
+      	      VIRTUAL_PROTOTYPE = TARGET + 'Prototype';
+      	      if (!hasOwn(path, VIRTUAL_PROTOTYPE)) {
+      	        createNonEnumerableProperty(path, VIRTUAL_PROTOTYPE, {});
+      	      }
+      	      // export virtual prototype methods
+      	      createNonEnumerableProperty(path[VIRTUAL_PROTOTYPE], key, sourceProperty);
+      	      // export real prototype methods
+      	      if (options.real && targetPrototype && (FORCED || !targetPrototype[key])) {
+      	        createNonEnumerableProperty(targetPrototype, key, sourceProperty);
+      	      }
+      	    }
+      	  }
+      	};
+      	return _export;
+      }
+
+      var mathTrunc;
+      var hasRequiredMathTrunc;
+
+      function requireMathTrunc () {
+      	if (hasRequiredMathTrunc) return mathTrunc;
+      	hasRequiredMathTrunc = 1;
+      	var ceil = Math.ceil;
+      	var floor = Math.floor;
+
+      	// `Math.trunc` method
+      	// https://tc39.es/ecma262/#sec-math.trunc
+      	// eslint-disable-next-line es/no-math-trunc -- safe
+      	mathTrunc = Math.trunc || function trunc(x) {
+      	  var n = +x;
+      	  return (n > 0 ? floor : ceil)(n);
+      	};
+      	return mathTrunc;
+      }
+
+      var toIntegerOrInfinity;
+      var hasRequiredToIntegerOrInfinity;
+
+      function requireToIntegerOrInfinity () {
+      	if (hasRequiredToIntegerOrInfinity) return toIntegerOrInfinity;
+      	hasRequiredToIntegerOrInfinity = 1;
+      	var trunc = requireMathTrunc();
+
+      	// `ToIntegerOrInfinity` abstract operation
+      	// https://tc39.es/ecma262/#sec-tointegerorinfinity
+      	toIntegerOrInfinity = function (argument) {
+      	  var number = +argument;
+      	  // eslint-disable-next-line no-self-compare -- NaN check
+      	  return number !== number || number === 0 ? 0 : trunc(number);
+      	};
+      	return toIntegerOrInfinity;
+      }
+
+      var toAbsoluteIndex;
+      var hasRequiredToAbsoluteIndex;
+
+      function requireToAbsoluteIndex () {
+      	if (hasRequiredToAbsoluteIndex) return toAbsoluteIndex;
+      	hasRequiredToAbsoluteIndex = 1;
+      	var toIntegerOrInfinity = requireToIntegerOrInfinity();
+
+      	var max = Math.max;
+      	var min = Math.min;
+
+      	// Helper for a popular repeating case of the spec:
+      	// Let integer be ? ToInteger(index).
+      	// If integer < 0, let result be max((length + integer), 0); else let result be min(integer, length).
+      	toAbsoluteIndex = function (index, length) {
+      	  var integer = toIntegerOrInfinity(index);
+      	  return integer < 0 ? max(integer + length, 0) : min(integer, length);
+      	};
+      	return toAbsoluteIndex;
+      }
+
+      var toLength;
+      var hasRequiredToLength;
+
+      function requireToLength () {
+      	if (hasRequiredToLength) return toLength;
+      	hasRequiredToLength = 1;
+      	var toIntegerOrInfinity = requireToIntegerOrInfinity();
+
+      	var min = Math.min;
+
+      	// `ToLength` abstract operation
+      	// https://tc39.es/ecma262/#sec-tolength
+      	toLength = function (argument) {
+      	  var len = toIntegerOrInfinity(argument);
+      	  return len > 0 ? min(len, 0x1FFFFFFFFFFFFF) : 0; // 2 ** 53 - 1 == 9007199254740991
+      	};
+      	return toLength;
+      }
+
+      var lengthOfArrayLike;
+      var hasRequiredLengthOfArrayLike;
+
+      function requireLengthOfArrayLike () {
+      	if (hasRequiredLengthOfArrayLike) return lengthOfArrayLike;
+      	hasRequiredLengthOfArrayLike = 1;
+      	var toLength = requireToLength();
+
+      	// `LengthOfArrayLike` abstract operation
+      	// https://tc39.es/ecma262/#sec-lengthofarraylike
+      	lengthOfArrayLike = function (obj) {
+      	  return toLength(obj.length);
+      	};
+      	return lengthOfArrayLike;
+      }
+
+      var arrayIncludes;
+      var hasRequiredArrayIncludes;
+
+      function requireArrayIncludes () {
+      	if (hasRequiredArrayIncludes) return arrayIncludes;
+      	hasRequiredArrayIncludes = 1;
+      	var toIndexedObject = requireToIndexedObject();
+      	var toAbsoluteIndex = requireToAbsoluteIndex();
+      	var lengthOfArrayLike = requireLengthOfArrayLike();
+
+      	// `Array.prototype.{ indexOf, includes }` methods implementation
+      	var createMethod = function (IS_INCLUDES) {
+      	  return function ($this, el, fromIndex) {
+      	    var O = toIndexedObject($this);
+      	    var length = lengthOfArrayLike(O);
+      	    if (length === 0) return !IS_INCLUDES && -1;
+      	    var index = toAbsoluteIndex(fromIndex, length);
+      	    var value;
+      	    // Array#includes uses SameValueZero equality algorithm
+      	    // eslint-disable-next-line no-self-compare -- NaN check
+      	    if (IS_INCLUDES && el !== el) while (length > index) {
+      	      value = O[index++];
+      	      // eslint-disable-next-line no-self-compare -- NaN check
+      	      if (value !== value) return true;
+      	    // Array#indexOf ignores holes, Array#includes - not
+      	    } else for (;length > index; index++) {
+      	      if ((IS_INCLUDES || index in O) && O[index] === el) return IS_INCLUDES || index || 0;
+      	    } return !IS_INCLUDES && -1;
+      	  };
+      	};
+
+      	arrayIncludes = {
+      	  // `Array.prototype.includes` method
+      	  // https://tc39.es/ecma262/#sec-array.prototype.includes
+      	  includes: createMethod(true),
+      	  // `Array.prototype.indexOf` method
+      	  // https://tc39.es/ecma262/#sec-array.prototype.indexof
+      	  indexOf: createMethod(false)
+      	};
+      	return arrayIncludes;
+      }
+
+      var hiddenKeys;
+      var hasRequiredHiddenKeys;
+
+      function requireHiddenKeys () {
+      	if (hasRequiredHiddenKeys) return hiddenKeys;
+      	hasRequiredHiddenKeys = 1;
+      	hiddenKeys = {};
+      	return hiddenKeys;
+      }
+
+      var objectKeysInternal;
+      var hasRequiredObjectKeysInternal;
+
+      function requireObjectKeysInternal () {
+      	if (hasRequiredObjectKeysInternal) return objectKeysInternal;
+      	hasRequiredObjectKeysInternal = 1;
+      	var uncurryThis = requireFunctionUncurryThis();
+      	var hasOwn = requireHasOwnProperty();
+      	var toIndexedObject = requireToIndexedObject();
+      	var indexOf = requireArrayIncludes().indexOf;
+      	var hiddenKeys = requireHiddenKeys();
+
+      	var push = uncurryThis([].push);
+
+      	objectKeysInternal = function (object, names) {
+      	  var O = toIndexedObject(object);
+      	  var i = 0;
+      	  var result = [];
+      	  var key;
+      	  for (key in O) !hasOwn(hiddenKeys, key) && hasOwn(O, key) && push(result, key);
+      	  // Don't enum bug & hidden keys
+      	  while (names.length > i) if (hasOwn(O, key = names[i++])) {
+      	    ~indexOf(result, key) || push(result, key);
+      	  }
+      	  return result;
+      	};
+      	return objectKeysInternal;
+      }
+
+      var enumBugKeys;
+      var hasRequiredEnumBugKeys;
+
+      function requireEnumBugKeys () {
+      	if (hasRequiredEnumBugKeys) return enumBugKeys;
+      	hasRequiredEnumBugKeys = 1;
+      	// IE8- don't enum bug keys
+      	enumBugKeys = [
+      	  'constructor',
+      	  'hasOwnProperty',
+      	  'isPrototypeOf',
+      	  'propertyIsEnumerable',
+      	  'toLocaleString',
+      	  'toString',
+      	  'valueOf'
+      	];
+      	return enumBugKeys;
+      }
+
+      var objectKeys;
+      var hasRequiredObjectKeys;
+
+      function requireObjectKeys () {
+      	if (hasRequiredObjectKeys) return objectKeys;
+      	hasRequiredObjectKeys = 1;
+      	var internalObjectKeys = requireObjectKeysInternal();
+      	var enumBugKeys = requireEnumBugKeys();
+
+      	// `Object.keys` method
+      	// https://tc39.es/ecma262/#sec-object.keys
+      	// eslint-disable-next-line es/no-object-keys -- safe
+      	objectKeys = Object.keys || function keys(O) {
+      	  return internalObjectKeys(O, enumBugKeys);
+      	};
+      	return objectKeys;
+      }
+
+      var objectGetOwnPropertySymbols = {};
+
+      var hasRequiredObjectGetOwnPropertySymbols;
+
+      function requireObjectGetOwnPropertySymbols () {
+      	if (hasRequiredObjectGetOwnPropertySymbols) return objectGetOwnPropertySymbols;
+      	hasRequiredObjectGetOwnPropertySymbols = 1;
+      	// eslint-disable-next-line es/no-object-getownpropertysymbols -- safe
+      	objectGetOwnPropertySymbols.f = Object.getOwnPropertySymbols;
+      	return objectGetOwnPropertySymbols;
+      }
+
+      var objectAssign;
+      var hasRequiredObjectAssign;
+
+      function requireObjectAssign () {
+      	if (hasRequiredObjectAssign) return objectAssign;
+      	hasRequiredObjectAssign = 1;
+      	var DESCRIPTORS = requireDescriptors();
+      	var uncurryThis = requireFunctionUncurryThis();
+      	var call = requireFunctionCall();
+      	var fails = requireFails();
+      	var objectKeys = requireObjectKeys();
+      	var getOwnPropertySymbolsModule = requireObjectGetOwnPropertySymbols();
+      	var propertyIsEnumerableModule = requireObjectPropertyIsEnumerable();
+      	var toObject = requireToObject();
+      	var IndexedObject = requireIndexedObject();
+
+      	// eslint-disable-next-line es/no-object-assign -- safe
+      	var $assign = Object.assign;
+      	// eslint-disable-next-line es/no-object-defineproperty -- required for testing
+      	var defineProperty = Object.defineProperty;
+      	var concat = uncurryThis([].concat);
+
+      	// `Object.assign` method
+      	// https://tc39.es/ecma262/#sec-object.assign
+      	objectAssign = !$assign || fails(function () {
+      	  // should have correct order of operations (Edge bug)
+      	  if (DESCRIPTORS && $assign({ b: 1 }, $assign(defineProperty({}, 'a', {
+      	    enumerable: true,
+      	    get: function () {
+      	      defineProperty(this, 'b', {
+      	        value: 3,
+      	        enumerable: false
+      	      });
+      	    }
+      	  }), { b: 2 })).b !== 1) return true;
+      	  // should work with symbols and should have deterministic property order (V8 bug)
+      	  var A = {};
+      	  var B = {};
+      	  // eslint-disable-next-line es/no-symbol -- safe
+      	  var symbol = Symbol('assign detection');
+      	  var alphabet = 'abcdefghijklmnopqrst';
+      	  A[symbol] = 7;
+      	  // eslint-disable-next-line es/no-array-prototype-foreach -- safe
+      	  alphabet.split('').forEach(function (chr) { B[chr] = chr; });
+      	  return $assign({}, A)[symbol] !== 7 || objectKeys($assign({}, B)).join('') !== alphabet;
+      	}) ? function assign(target, source) { // eslint-disable-line no-unused-vars -- required for `.length`
+      	  var T = toObject(target);
+      	  var argumentsLength = arguments.length;
+      	  var index = 1;
+      	  var getOwnPropertySymbols = getOwnPropertySymbolsModule.f;
+      	  var propertyIsEnumerable = propertyIsEnumerableModule.f;
+      	  while (argumentsLength > index) {
+      	    var S = IndexedObject(arguments[index++]);
+      	    var keys = getOwnPropertySymbols ? concat(objectKeys(S), getOwnPropertySymbols(S)) : objectKeys(S);
+      	    var length = keys.length;
+      	    var j = 0;
+      	    var key;
+      	    while (length > j) {
+      	      key = keys[j++];
+      	      if (!DESCRIPTORS || call(propertyIsEnumerable, S, key)) T[key] = S[key];
+      	    }
+      	  } return T;
+      	} : $assign;
+      	return objectAssign;
+      }
+
+      var hasRequiredEs_object_assign;
+
+      function requireEs_object_assign () {
+      	if (hasRequiredEs_object_assign) return es_object_assign;
+      	hasRequiredEs_object_assign = 1;
+      	var $ = require_export();
+      	var assign = requireObjectAssign();
+
+      	// `Object.assign` method
+      	// https://tc39.es/ecma262/#sec-object.assign
+      	// eslint-disable-next-line es/no-object-assign -- required for testing
+      	$({ target: 'Object', stat: true, arity: 2, forced: Object.assign !== assign }, {
+      	  assign: assign
+      	});
+      	return es_object_assign;
+      }
+
+      var assign$2;
+      var hasRequiredAssign$2;
+
+      function requireAssign$2 () {
+      	if (hasRequiredAssign$2) return assign$2;
+      	hasRequiredAssign$2 = 1;
+      	requireEs_object_assign();
+      	var path = requirePath();
+
+      	assign$2 = path.Object.assign;
+      	return assign$2;
+      }
+
+      var assign$1;
+      var hasRequiredAssign$1;
+
+      function requireAssign$1 () {
+      	if (hasRequiredAssign$1) return assign$1;
+      	hasRequiredAssign$1 = 1;
+      	var parent = requireAssign$2();
+
+      	assign$1 = parent;
+      	return assign$1;
+      }
+
+      var assign;
+      var hasRequiredAssign;
+
+      function requireAssign () {
+      	if (hasRequiredAssign) return assign;
+      	hasRequiredAssign = 1;
+      	assign = requireAssign$1();
+      	return assign;
+      }
+
+      var assignExports = requireAssign();
+      const _Object$assign = /*@__PURE__*/getDefaultExportFromCjs(assignExports);
+
+      function a () {
+        console.log(_Object$assign({}, {
+          a: 1
+        }));
+      }
+
+      function b () {
+        console.log(_Object$assign({}, {
+          b: 1
+        }));
+      }
+
+      a();
+      b();
     JS
   end
   
@@ -1579,17 +1574,12 @@ class CondenserBabelTest < ActiveSupport::TestCase
     JS
   
     assert_exported_file 'name.js', 'application/javascript', <<~JS
-      (function () {
-        'use strict';
-  
-        function x(y) {
-          return y === null || y === void 0 ? void 0 : y.z;
-        }
-  
-        var d = {};
-        console.log(x(d === null || d === void 0 ? void 0 : d.z));
-  
-      })();
+      function x(y) {
+        return y === null || y === void 0 ? void 0 : y.z;
+      }
+
+      var d = {};
+      console.log(x(d === null || d === void 0 ? void 0 : d.z));
     JS
   
   end

--- a/test/preprocessor/js_analyzer_test.rb
+++ b/test/preprocessor/js_analyzer_test.rb
@@ -97,16 +97,16 @@ class JSAnalyzerTest < ActiveSupport::TestCase
     asset = @env.find('name.js')
     assert_nil asset.exports
     assert_equal [
+        "module-name/path/to/specific/un-exported/file6.js",
         "module-name1.js",
+        "module-name10.js",
         "module-name2.js",
         "module-name3.js",
         "module-name4.js",
         "module-name5.js",
-        "module-name/path/to/specific/un-exported/file6.js",
         "module-name7.js",
         "module-name8.js",
-        "module-name9.js",
-        "module-name10.js"
+        "module-name9.js"
       ], asset.export_dependencies.map(&:filename)
   end
 

--- a/test/preprocessor/js_analyzer_test.rb
+++ b/test/preprocessor/js_analyzer_test.rb
@@ -49,7 +49,7 @@ class JSAnalyzerTest < ActiveSupport::TestCase
       ')': '&#41;',
     };
 
-    var resc = /[<>&\(\)\[\]"']/g;
+    var resc = /[<>&\(\)\\[\\]"']/g;
 
     JS
 
@@ -279,8 +279,38 @@ class JSAnalyzerTest < ActiveSupport::TestCase
           }
       };
     JS
-    
+  end
+
+  test 'regex chars that dont need escaping' do
+    file 'a.js', 'this._agsAdmin=/(https?:\/\/[^/]+\/[^/]+)\/admin\/?(\/.*)?$/i'
+    asset = assert_file 'a.js', 'application/javascript'
+
+    file 'b.js', 'function T(e){return e.replaceAll(/[|\\{}()[\]^$+*?.]/g,"\\$&")}'
+    asset = assert_file 'b.js', 'application/javascript'
+
+    file 'c.js', 'f=/(?:LENGTH)?UNIT\[([^\]]+)]]$/i'
+    asset = assert_file 'c.js', 'application/javascript'
+
+    file 'd.js', 'function o(t,e){return t.replaceAll(/([.$?*|{}()[\]\\\\/+\-^])/g,(t=>e?.includes(t)?t:`\\${t}`))}'
+    asset = assert_file 'd.js', 'application/javascript'
+  end
+
+  test 'a regex after a function call or for loop' do
+    file 't.js', <<~JS
+      for(const s in r)/^(request|service)$/i.test(s)&&delete r[s];
+    JS
+
     asset = assert_file 't.js', 'application/javascript'
+    file 'b.js', <<~JS
+      e=>Math.round(1e4*e)/1e4;
+    JS
+
+    asset = assert_file 'b.js', 'application/javascript'
+    file 'c.js', <<~JS
+      {const e=this._timings.entries,t=e.length;let s=0;for(const r of e)s+=r;r=s/t}
+    JS
+
+    asset = assert_file 'c.js', 'application/javascript'
   end
 
 end

--- a/test/preprocessor/js_analyzer_test.rb
+++ b/test/preprocessor/js_analyzer_test.rb
@@ -313,4 +313,24 @@ class JSAnalyzerTest < ActiveSupport::TestCase
     asset = assert_file 'c.js', 'application/javascript'
   end
 
+  test 'file with a keyword as start of a function name' do
+    file 'name.js', <<~JS
+      export default class Admin extends User {
+
+          static aroundActions = ['requireAdmin']
+    
+          async imports () {
+              this.display(imports, {
+                  user: this.application.session.user
+              }, { layout })
+          }
+      }
+    JS
+
+    asset = @env.find('name.js')
+    assert asset.exports
+    assert asset.has_default_export?
+    assert_empty asset.export_dependencies
+  end
+
 end

--- a/test/processors/rollup/dynamic_import_test.rb
+++ b/test/processors/rollup/dynamic_import_test.rb
@@ -81,7 +81,7 @@ class RollupDynamicImportTestTest < ActiveSupport::TestCase
 
   test "dynamic imports don't inlined and are exported" do
     @env.unregister_exporter 'application/javascript'
-    @env.register_exporter 'application/javascript', Condenser::RollupProcessor.new(@env.npm_path, inline: false)
+    @env.register_exporter 'application/javascript', Condenser::RollupProcessor.new(@env.npm_path, dynamic_imports: false)
 
     file 'main.js', <<~JS
       cube = await import('./math/math');
@@ -174,7 +174,7 @@ class RollupDynamicImportTestTest < ActiveSupport::TestCase
 
   test "dynamic imports with a prefix" do
     @env.unregister_exporter 'application/javascript'
-    @env.register_exporter 'application/javascript', Condenser::RollupProcessor.new(@env.npm_path, prefix: "/assets", inline: false)
+    @env.register_exporter 'application/javascript', Condenser::RollupProcessor.new(@env.npm_path, prefix: "/assets", dynamic_imports: false)
 
     file 'main.js', <<~JS
       cube = await import('./math/math');
@@ -267,7 +267,7 @@ class RollupDynamicImportTestTest < ActiveSupport::TestCase
 
   test "cyclical dynamic imports don't inlined and are exported" do
     @env.unregister_exporter 'application/javascript'
-    @env.register_exporter 'application/javascript', Condenser::RollupProcessor.new(@env.npm_path, inline: false)
+    @env.register_exporter 'application/javascript', Condenser::RollupProcessor.new(@env.npm_path, dynamic_imports: false)
 
     file 'main.js', <<~JS
       const cube = await import('./math/math');

--- a/test/processors/rollup/dynamic_import_test.rb
+++ b/test/processors/rollup/dynamic_import_test.rb
@@ -1,0 +1,358 @@
+require 'test_helper'
+
+class RollupDynamicImportTestTest < ActiveSupport::TestCase
+  
+  def setup
+    super
+    @env.unregister_minifier('application/javascript')
+  end
+ 
+  test 'dynamic imports get inlined' do
+    file 'main.js', <<~JS
+      cube = await import('./math/math');
+      bigCube = await import('math/b');
+
+      console.log( cube( 5 ) ); // 125
+    JS
+
+    file 'math/cube.js', <<~JS
+      export default function cube ( x ) {
+        return x * x * x;
+      }
+    JS
+    file 'math/math.js', <<~JS
+      import cube from './cube';
+
+      export {cube};
+    JS
+    file 'math/b.js', <<~JS
+      import cube from './cube';
+      let b = x;
+      export {cube};
+    JS
+
+    assert_exported_file 'main.js', 'application/javascript', <<~FILE
+      function cube$1 ( x ) {
+        return x * x * x;
+      }
+
+      const math = /*#__PURE__*/Object.freeze(/*#__PURE__*/Object.defineProperty({
+        __proto__: null,
+        cube: cube$1
+      }, Symbol.toStringTag, { value: 'Module' }));
+
+      x;
+
+      const b = /*#__PURE__*/Object.freeze(/*#__PURE__*/Object.defineProperty({
+        __proto__: null,
+        cube: cube$1
+      }, Symbol.toStringTag, { value: 'Module' }));
+
+      cube = await Promise.resolve().then(() => math);
+      bigCube = await Promise.resolve().then(() => b);
+
+      console.log( cube( 5 ) ); // 125
+    FILE
+  end
+
+  test 'file with dynamic imports' do
+    1.upto(3) do |i|
+      if i == 3
+        file "module-name/path/to/specific/un-exported/file#{i}.js", "#{i}"
+      else
+        file "module-name#{i}.js", "#{i}"
+      end
+    end
+
+    file 'name.js', <<~JS
+      let x = await import("module-name1");
+      let y = import("module-name2");
+      import("module-name/path/to/specific/un-exported/file3");
+    JS
+
+    asset = @env.find('name.js')
+    assert_nil asset.exports
+    assert_equal [
+      "module-name1.js",
+      "module-name2.js",
+      "module-name/path/to/specific/un-exported/file3.js"
+    ], asset.linked_assets.map(&:filename)
+  end
+
+  test "dynamic imports don't inlined and are exported" do
+    @env.unregister_exporter 'application/javascript'
+    @env.register_exporter 'application/javascript', Condenser::RollupProcessor.new(@env.npm_path, inline: false)
+
+    file 'main.js', <<~JS
+      cube = await import('./math/math');
+      bigCube = await import('math/b');
+
+      console.log( cube( 5 ) ); // 125
+    JS
+
+    file 'math/cube.js', <<~JS
+      export default function cube ( x ) {
+        return x * x * x;
+      }
+    JS
+    file 'math/math.js', <<~JS
+      import cube from './cube';
+
+      export {cube};
+    JS
+    file 'math/b.js', <<~JS
+      import cube from './cube';
+      let b = x;
+      export {cube};
+    JS
+
+    assert_exported_file 'main.js', 'application/javascript', <<~FILE
+      cube = await import('/#{@env.find('math/math').path}');
+      bigCube = await import('/#{@env.find('math/b').path}');
+
+      console.log( cube( 5 ) ); // 125
+    FILE
+
+    Dir.mktmpdir do |export_dir|
+      manifest = Condenser::Manifest.new(@env, File.join(export_dir, 'manifest.json'))
+      main = @env['main.js']
+      math = @env['math/math.js']
+      mathb = @env['math/b.js']
+      assets = [main, math, mathb]
+
+      assets.each do |asset|
+        assert !File.exist?("#{export_dir}/#{asset.path}")
+      end
+
+      manifest.compile('main.js')
+      assert File.directory?(manifest.dir)
+      assert File.file?(manifest.filename)
+      assert File.exist?("#{export_dir}/manifest.json")
+
+      assets.each do |asset|
+        assert File.exist?("#{export_dir}/#{asset.path}")
+        assert File.exist?("#{export_dir}/#{asset.path}.gz")
+      end
+
+      data = JSON.parse(File.read(manifest.filename))
+
+      assert data['main.js']
+      assert_equal 240, data['main.js']['size']
+      assert_equal main.path, data['main.js']['path']
+      assert_equal(<<~JS.rstrip, File.read(File.join(export_dir, data['main.js']['path'])).rstrip)
+        cube = await import('/#{math.path}');
+        bigCube = await import('/#{mathb.path}');
+
+        console.log( cube( 5 ) ); // 125
+      JS
+
+      assert data['math/math.js']
+      assert_equal 62, data['math/math.js']['size']
+      assert_equal math.path, data['math/math.js']['path']
+      assert_equal(<<~JS.rstrip, File.read(File.join(export_dir, data['math/math.js']['path'])).rstrip)
+        function cube ( x ) {
+          return x * x * x;
+        }
+
+        export { cube };
+      JS
+
+      assert data['math/b.js']
+      assert_equal 66, data['math/b.js']['size']
+      assert_equal mathb.path, data['math/b.js']['path']
+      assert_equal(<<~JS.rstrip, File.read(File.join(export_dir, data['math/b.js']['path'])).rstrip)
+        function cube ( x ) {
+          return x * x * x;
+        }
+
+        x;
+
+        export { cube };
+      JS
+    end
+  end
+
+  test "dynamic imports with a prefix" do
+    @env.unregister_exporter 'application/javascript'
+    @env.register_exporter 'application/javascript', Condenser::RollupProcessor.new(@env.npm_path, prefix: "/assets", inline: false)
+
+    file 'main.js', <<~JS
+      cube = await import('./math/math');
+      bigCube = await import('math/b');
+
+      console.log( cube( 5 ) ); // 125
+    JS
+
+    file 'math/cube.js', <<~JS
+      export default function cube ( x ) {
+        return x * x * x;
+      }
+    JS
+    file 'math/math.js', <<~JS
+      import cube from './cube';
+
+      export {cube};
+    JS
+    file 'math/b.js', <<~JS
+      import cube from './cube';
+      let b = x;
+      export {cube};
+    JS
+
+    assert_exported_file 'main.js', 'application/javascript', <<~FILE
+      cube = await import('/assets/#{@env.find('math/math').path}');
+      bigCube = await import('/assets/#{@env.find('math/b').path}');
+
+      console.log( cube( 5 ) ); // 125
+    FILE
+
+    Dir.mktmpdir do |export_dir|
+      manifest = Condenser::Manifest.new(@env, File.join(export_dir, 'manifest.json'))
+      main = @env['main.js']
+      math = @env['math/math.js']
+      mathb = @env['math/b.js']
+      assets = [main, math, mathb]
+
+      assets.each do |asset|
+        assert !File.exist?("#{export_dir}/#{asset.path}")
+      end
+
+      manifest.compile('main.js')
+      assert File.directory?(manifest.dir)
+      assert File.file?(manifest.filename)
+      assert File.exist?("#{export_dir}/manifest.json")
+
+      assets.each do |asset|
+        assert File.exist?("#{export_dir}/#{asset.path}")
+        assert File.exist?("#{export_dir}/#{asset.path}.gz")
+      end
+
+      data = JSON.parse(File.read(manifest.filename))
+
+      assert data['main.js']
+      assert_equal 254, data['main.js']['size']
+      assert_equal main.path, data['main.js']['path']
+      assert_equal(<<~JS.rstrip, File.read(File.join(export_dir, data['main.js']['path'])).rstrip)
+        cube = await import('/assets/#{math.path}');
+        bigCube = await import('/assets/#{mathb.path}');
+
+        console.log( cube( 5 ) ); // 125
+      JS
+
+      assert data['math/math.js']
+      assert_equal 62, data['math/math.js']['size']
+      assert_equal math.path, data['math/math.js']['path']
+      assert_equal(<<~JS.rstrip, File.read(File.join(export_dir, data['math/math.js']['path'])).rstrip)
+        function cube ( x ) {
+          return x * x * x;
+        }
+
+        export { cube };
+      JS
+
+      assert data['math/b.js']
+      assert_equal 66, data['math/b.js']['size']
+      assert_equal mathb.path, data['math/b.js']['path']
+      assert_equal(<<~JS.rstrip, File.read(File.join(export_dir, data['math/b.js']['path'])).rstrip)
+        function cube ( x ) {
+          return x * x * x;
+        }
+
+        x;
+
+        export { cube };
+      JS
+    end
+  end
+
+  test "cyclical dynamic imports don't inlined and are exported" do
+    @env.unregister_exporter 'application/javascript'
+    @env.register_exporter 'application/javascript', Condenser::RollupProcessor.new(@env.npm_path, inline: false)
+
+    file 'main.js', <<~JS
+      const cube = await import('./math/math');
+
+      console.log( cube( 5 ) ); // 125
+    JS
+
+    file 'math/cube.js', <<~JS
+      const math = await import('./math');
+
+      export default function cube ( x ) {
+        return math.number(x) * x * x;
+      }
+    JS
+    file 'math/math.js', <<~JS
+      import cube from './cube';
+
+      function number (x) { return x; }
+
+      export {cube, number};
+    JS
+
+    assert_exported_file 'main.js', 'application/javascript', <<~FILE
+      const cube = await import('/#{@env.find('/math/math').export.path}');
+
+      console.log( cube( 5 ) ); // 125
+    FILE
+
+    Dir.mktmpdir do |export_dir|
+      manifest = Condenser::Manifest.new(@env, File.join(export_dir, 'manifest.json'))
+      main = @env['main.js']
+      math = @env['math/math.js']
+      cube = @env['math/cube.js']
+      assets = [main, math]
+
+      assets.each do |asset|
+        assert !File.exist?("#{export_dir}/#{asset.path}")
+      end
+
+      manifest.compile('main.js')
+      assert File.directory?(manifest.dir)
+      assert File.file?(manifest.filename)
+      assert File.exist?("#{export_dir}/manifest.json")
+
+      assets.each do |asset|
+        assert File.exist?("#{export_dir}/#{asset.path}")
+        assert File.exist?("#{export_dir}/#{asset.path}.gz")
+      end
+
+      data = JSON.parse(File.read(manifest.filename))
+
+      assert_equal ["main.js", "math/math.js"], data.keys
+
+      assert data['main.js']
+      assert_equal 143, data['main.js']['size']
+      assert_equal main.path, data['main.js']['path']
+      assert_equal(<<~JS.rstrip, File.read(File.join(export_dir, data['main.js']['path'])).rstrip)
+        const cube = await import('/#{math.path}');
+
+        console.log( cube( 5 ) ); // 125
+      JS
+
+      assert data['math/math.js']
+      assert_equal 336, data['math/math.js']['size']
+      assert_equal math.path, data['math/math.js']['path']
+      assert_equal(<<~JS.rstrip, File.read(File.join(export_dir, data['math/math.js']['path'])).rstrip)
+        const math = await Promise.resolve().then(() => entry);
+
+        function cube ( x ) {
+          return math.number(x) * x * x;
+        }
+
+        function number (x) { return x; }
+
+        const entry = /*#__PURE__*/Object.freeze(/*#__PURE__*/Object.defineProperty({
+          __proto__: null,
+          cube,
+          number
+        }, Symbol.toStringTag, { value: 'Module' }));
+
+        export { cube, number };
+      JS
+    end
+  end
+
+  #TODO: add test for inilne / not inline URLs
+
+end

--- a/test/processors/rollup_test.rb
+++ b/test/processors/rollup_test.rb
@@ -28,17 +28,12 @@ class RollupTest < ActiveSupport::TestCase
     JS
 
     assert_exported_file 'main.js', 'application/javascript', <<~FILE
-      (function () {
-        'use strict';
-
         // This function gets included
         function cube ( x ) {
           return x * x * x;
         }
 
         console.log( cube( 5 ) ); // 125
-
-      })();
     FILE
   end
   
@@ -55,16 +50,11 @@ class RollupTest < ActiveSupport::TestCase
     JS
 
     assert_exported_file 'main.js', 'application/javascript', <<~FILE
-      (function () {
-        'use strict';
+      function cube ( x ) {
+        return 2 * x * x;
+      }
 
-        function cube ( x ) {
-          return 2 * x * x;
-        }
-
-        console.log( cube( 5 ) ); // 125
-
-      })();
+      console.log( cube( 5 ) ); // 125
     FILE
   end
 
@@ -89,16 +79,11 @@ class RollupTest < ActiveSupport::TestCase
     @env.append_path File.join(@path, 'a')
 
     assert_exported_file 'main.js', 'application/javascript', <<~FILE
-      (function () {
-        'use strict';
-
         function cube ( x ) {
           return x * x * x;
         }
 
         console.log( cube( 5 ) ); // 125
-
-      })();
     FILE
   end
 
@@ -122,20 +107,15 @@ class RollupTest < ActiveSupport::TestCase
     JS
 
     assert_exported_file 'main.js', 'application/javascript', <<~FILE
-      (function () {
-        'use strict';
+      window.cube = function ( x ) {
+        return x * x * x;
+      };
 
-        window.cube = function ( x ) {
-          return x * x * x;
-        };
+      window.square = function ( x ) {
+        return x * x;
+      };
 
-        window.square = function ( x ) {
-          return x * x;
-        };
-
-        console.log( square(cube( 5 )) );
-
-      })();
+      console.log( square(cube( 5 )) );
     FILE
   end
 
@@ -164,26 +144,21 @@ class RollupTest < ActiveSupport::TestCase
     JS
 
     assert_exported_file 'main.js', 'application/javascript', <<~FILE
-      (function () {
-        'use strict';
+      function cube ( x ) {
+        return x * x * x;
+      }
 
-        function cube ( x ) {
-          return x * x * x;
-        }
+      function square ( x ) {
+        return x * x;
+      }
 
-        function square ( x ) {
-          return x * x;
-        }
+      const maths = [cube, square];
 
-        var maths = [cube, square];
-
-        var x = 1;
-        for (var i = 0; i < maths.length; i++) {
-          x = maths[i](x);
-        }
-        console.log(x);
-
-      })();
+      var x = 1;
+      for (var i = 0; i < maths.length; i++) {
+        x = maths[i](x);
+      }
+      console.log(x);
     FILE
     $d = false
   end
@@ -208,16 +183,11 @@ class RollupTest < ActiveSupport::TestCase
 
 
     assert_exported_file 'main.js', 'application/javascript', <<~FILE
-      (function () {
-      	'use strict';
+      class Base { }
 
-      	class Base { }
+      class Lower extends Base { }
 
-      	class Lower extends Base { }
-
-      	console.log( Base, Lower );
-
-      })();
+      console.log( Base, Lower );
     FILE
   end
 

--- a/test/resolve_test.rb
+++ b/test/resolve_test.rb
@@ -94,16 +94,11 @@ class ResolveTest < ActiveSupport::TestCase
     @env.append_path File.join(@path, 'a')
 
     assert_exported_file('main.js', 'application/javascript', <<~JS)
-      (function () {
-        'use strict';
+      function cube ( x ) {
+        return x * x * x;
+      }
 
-        function cube ( x ) {
-          return x * x * x;
-        }
-
-        console.log( cube( 5 ) ); // 125
-
-      })();
+      console.log( cube( 5 ) ); // 125
     JS
   end
   

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 require 'rack/builder'
 require 'rack/test'
+require 'rack/lint'
 
 class ServerTest < ActiveSupport::TestCase
   include Rack::Test::Methods

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -54,7 +54,7 @@ class ServerTest < ActiveSupport::TestCase
 
     get "/assets/main.js"
     assert_equal <<~JS.strip, last_response.body
-      (()=>{var o;console.log((o=5)*o*o)})();
+      function cube(c){return c*c*c}console.log(cube(5));
     JS
   end
 
@@ -73,7 +73,7 @@ class ServerTest < ActiveSupport::TestCase
   test "serve source with etag headers" do
     get "/assets/foo.js"
 
-    digest = '35c146f76e129477c64061bc84511e1090f3d4d8059713e6663dd4b35b1f7642'
+    digest = 'b603d946eb2b396ca4ecf65c223daff659dbe6f1cfeac235b7c61d3ba6964cae'
     assert_equal "\"#{digest}\"", last_response.headers['ETag']
   end
 
@@ -107,7 +107,7 @@ class ServerTest < ActiveSupport::TestCase
       'HTTP_IF_NONE_MATCH' => "nope"
 
     assert_equal 200, last_response.status
-    assert_equal '"35c146f76e129477c64061bc84511e1090f3d4d8059713e6663dd4b35b1f7642"', last_response.headers['ETag']
+    assert_equal '"b603d946eb2b396ca4ecf65c223daff659dbe6f1cfeac235b7c61d3ba6964cae"', last_response.headers['ETag']
     assert_equal '15', last_response.headers['Content-Length']
   end
 
@@ -167,7 +167,7 @@ class ServerTest < ActiveSupport::TestCase
       'HTTP_IF_MATCH' => etag
 
     assert_equal 200, last_response.status
-    assert_equal '"35c146f76e129477c64061bc84511e1090f3d4d8059713e6663dd4b35b1f7642"', last_response.headers['ETag']
+    assert_equal '"b603d946eb2b396ca4ecf65c223daff659dbe6f1cfeac235b7c61d3ba6964cae"', last_response.headers['ETag']
     assert_equal '15', last_response.headers['Content-Length']
   end
 
@@ -253,7 +253,7 @@ class ServerTest < ActiveSupport::TestCase
     JS
     get "/assets/%E6%97%A5%E6%9C%AC%E8%AA%9E.js"
     assert_equal <<~JS.strip, last_response.body
-      console.log("日本語");
+      var japanese="日本語";console.log(japanese);
     JS
   end
 

--- a/test/transformers/dart_scss_test.rb
+++ b/test/transformers/dart_scss_test.rb
@@ -132,8 +132,8 @@ class CondenserDartSCSSTest < ActiveSupport::TestCase
     SCSS
 
     asset = @env.find('c.css')
-    assert_equal ["a.scss", "d.scss", "b.scss"], asset.process_dependencies.map(&:filename)
-    assert_equal ["a.scss", "d.scss", "b.scss"], asset.export_dependencies.map(&:filename)
+    assert_equal ["a.scss", "b.scss", "d.scss"], asset.process_dependencies.map(&:filename)
+    assert_equal ["a.scss", "b.scss", "d.scss"], asset.export_dependencies.map(&:filename)
   end
   
 end

--- a/test/transformers/scss_test.rb
+++ b/test/transformers/scss_test.rb
@@ -118,8 +118,8 @@ class CondenserSCSSTest < ActiveSupport::TestCase
     SCSS
     
     asset = @env.find('c.css')
-    assert_equal ["a.scss", "d.scss", "b.scss"], asset.process_dependencies.map(&:filename)
-    assert_equal ["a.scss", "d.scss", "b.scss"], asset.export_dependencies.map(&:filename)
+    assert_equal ["a.scss", "b.scss", "d.scss"], asset.process_dependencies.map(&:filename)
+    assert_equal ["a.scss", "b.scss", "d.scss"], asset.export_dependencies.map(&:filename)
   end
   
 end


### PR DESCRIPTION
**Etag**

`etag` of an assets is computed from the digest of all dependency file as opposed to the output. This allows rollup or other processor to change a file to links to a dependency which links back to the file in cyclical manor without going into an infinite loop updating the etags.

**Babel**

The Babel processor now only modifies the requires for the processor requires instead of all babel references

**CSSMediaCombiner**

Fix the end of string match in a Regex

**JSAnalyzer**

Ensure escaped and unescaped chars in Regex are parsed correctly

**Rollup**

- Just use one instance of Rollup to process a file and it's dependencies
- Change from 'iife' output to 'es' output format to reduce file size and support dynamic imports
- Adds the following option
  - prefix: A string to prefix to the url of dynamic imports
  - inline:

**Resolving**

- Add `npm:` option to resolve to allow serving the npm directory. Allows dynamic imports to import from the npm directory
